### PR TITLE
Check rpaths on MacOS

### DIFF
--- a/.ci/travis/update_rpaths.sh
+++ b/.ci/travis/update_rpaths.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+
+    executables="irf_test \
+        conflicting_instances_test \
+	get_value_test \
+        info_test \
+	set_value_test \
+        vargrid_test"
+
+    for exe in $executables; do
+	install_name_tool \
+	    -change @rpath/libgfortran.3.dylib \
+	            ${CONDA_PREFIX}/lib/libgfortran.3.dylib \
+	    -change @rpath/libquadmath.0.dylib \
+	            ${CONDA_PREFIX}/lib/libquadmath.0.dylib \
+	    ./testing/$exe
+	echo "Updated $exe"
+    done
+
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,7 @@ install:
   - cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install -DCMAKE_VERBOSE_MAKEFILE=True
   - make install
+before_script:
+  - source ../.ci/travis/update_rpaths.sh
 script:
   - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,5 @@ install:
   - cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install -DCMAKE_VERBOSE_MAKEFILE=True
   - make install
-before_script:
-  - source ../.ci/travis/update_rpaths.sh
 script:
   - ctest


### PR DESCRIPTION
I added a script that calls the MacOS `install_name_tool` program to update the rpaths for shared libraries used by the test executables.