### PR TITLE
Add BMI methods for unstructured grids

### DIFF
--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -243,12 +243,12 @@ module bmif
      end function bmif_get_grid_z
 
      ! Get the connectivity array of the nodes of an unstructured grid.
-     function bmif_get_grid_connectivity(self, grid_id, conn) &
+     function bmif_get_grid_connectivity(self, grid_id, connectivity) &
           result (bmi_status)
        import :: bmi
        class (bmi), intent (in) :: self
        integer, intent (in) :: grid_id
-       integer, dimension(:), intent (out) :: conn
+       integer, dimension(:), intent (out) :: connectivity
        integer :: bmi_status
      end function bmif_get_grid_connectivity
 

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -32,6 +32,11 @@ module bmif
        procedure (bmif_get_grid_size), deferred :: get_grid_size
        procedure (bmif_get_grid_spacing), deferred :: get_grid_spacing
        procedure (bmif_get_grid_origin), deferred :: get_grid_origin
+       procedure (bmif_get_grid_x), deferred :: get_grid_x
+       procedure (bmif_get_grid_y), deferred :: get_grid_y
+       procedure (bmif_get_grid_z), deferred :: get_grid_z
+       procedure (bmif_get_grid_connectivity), deferred :: get_grid_connectivity
+       procedure (bmif_get_grid_offset), deferred :: get_grid_offset
        procedure (bmif_get_var_type), deferred :: get_var_type
        procedure (bmif_get_var_units), deferred :: get_var_units
        procedure (bmif_get_var_itemsize), deferred :: get_var_itemsize
@@ -209,6 +214,53 @@ module bmif
        real, dimension(:), intent (out) :: origin
        integer :: bmi_status
      end function bmif_get_grid_origin
+
+     ! Get the x-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_x(self, grid_id, x) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       integer, intent (in) :: grid_id
+       real, dimension(:), intent (out) :: x
+       integer :: bmi_status
+     end function bmif_get_grid_x
+
+     ! Get the y-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_y(self, grid_id, y) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       integer, intent (in) :: grid_id
+       real, dimension(:), intent (out) :: y
+       integer :: bmi_status
+     end function bmif_get_grid_y
+
+     ! Get the z-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_z(self, grid_id, z) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       integer, intent (in) :: grid_id
+       real, dimension(:), intent (out) :: z
+       integer :: bmi_status
+     end function bmif_get_grid_z
+
+     ! Get the connectivity array of the nodes of an unstructured grid.
+     function bmif_get_grid_connectivity(self, grid_id, conn) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       integer, intent (in) :: grid_id
+       integer, dimension(:), intent (out) :: conn
+       integer :: bmi_status
+     end function bmif_get_grid_connectivity
+
+     ! Get the offsets of the nodes of an unstructured grid.
+     function bmif_get_grid_offset(self, grid_id, offset) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       integer, intent (in) :: grid_id
+       integer, dimension(:), intent (out) :: offset
+       integer :: bmi_status
+     end function bmif_get_grid_offset
 
      ! Get the data type of the given variable as a string.
      function bmif_get_var_type(self, var_name, type) result (bmi_status)

--- a/bmi/bmif.pc.cmake
+++ b/bmi/bmif.pc.cmake
@@ -2,4 +2,4 @@ Name: BMI
 Description: Basic Model Interface for Fortran
 Version: ${BMI_VERSION}
 Libs: -L${CMAKE_INSTALL_PREFIX}/lib -l${bmi_lib}
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include
+Cflags: -I${CMAKE_INSTALL_PREFIX}/include -std=f2003

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -29,6 +29,11 @@ module bmiheatf
      procedure :: get_grid_size => heat_grid_size
      procedure :: get_grid_spacing => heat_grid_spacing
      procedure :: get_grid_origin => heat_grid_origin
+     procedure :: get_grid_x => heat_grid_x
+     procedure :: get_grid_y => heat_grid_y
+     procedure :: get_grid_z => heat_grid_z
+     procedure :: get_grid_connectivity => heat_grid_connectivity
+     procedure :: get_grid_offset => heat_grid_offset
      procedure :: get_var_type => heat_var_type
      procedure :: get_var_units => heat_var_units
      procedure :: get_var_itemsize => heat_var_itemsize
@@ -48,6 +53,8 @@ module bmiheatf
   private :: heat_var_grid
   private :: heat_grid_type, heat_grid_rank, heat_grid_shape
   private :: heat_grid_size, heat_grid_spacing, heat_grid_origin
+  private :: heat_grid_x, heat_grid_y, heat_grid_z
+  private :: heat_grid_connectivity, heat_grid_offset
   private :: heat_var_type, heat_var_units, heat_var_itemsize, heat_var_nbytes
   private :: heat_get, heat_get_ref, heat_get_at_indices
   private :: heat_set, heat_set_at_indices
@@ -227,6 +234,9 @@ contains
     case ('plate_surface__temperature')
        grid_id = 0
        bmi_status = BMI_SUCCESS
+    case ('plate_surface__thermal_diffusivity')
+       grid_id = 1
+       bmi_status = BMI_SUCCESS
     case default
        grid_id = -1
        bmi_status = BMI_FAILURE
@@ -244,6 +254,9 @@ contains
     case (0)
        grid_type = "uniform_rectilinear"
        bmi_status = BMI_SUCCESS
+    case (1)
+       grid_type = "unstructured"
+       bmi_status = BMI_SUCCESS
     case default
        grid_type = "-"
        bmi_status = BMI_FAILURE
@@ -260,6 +273,9 @@ contains
     select case (grid_id)
     case (0)
        rank = 2
+       bmi_status = BMI_SUCCESS
+    case (1)
+       rank = 0
        bmi_status = BMI_SUCCESS
     case default
        rank = -1
@@ -294,6 +310,9 @@ contains
     select case (grid_id)
     case (0)
        size = self%model%n_y * self%model%n_x
+       bmi_status = BMI_SUCCESS
+    case (1)
+       size = 1
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -333,6 +352,88 @@ contains
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_origin
+
+  ! X-coordinates of grid nodes.
+  function heat_grid_x(self, grid_id, x) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    integer, intent (in) :: grid_id
+    real, dimension(:), intent (out) :: x
+    integer :: bmi_status
+
+    select case (grid_id)
+    case (1)
+       x = [0.0]
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_grid_x
+
+  ! Y-coordinates of grid nodes.
+  function heat_grid_y(self, grid_id, y) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    integer, intent (in) :: grid_id
+    real, dimension(:), intent (out) :: y
+    integer :: bmi_status
+
+    select case (grid_id)
+    case (1)
+       y = [0.0]
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_grid_y
+
+  ! Z-coordinates of grid nodes.
+  function heat_grid_z(self, grid_id, z) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    integer, intent (in) :: grid_id
+    real, dimension(:), intent (out) :: z
+    integer :: bmi_status
+
+    select case (grid_id)
+    case (1)
+       z = [0.0]
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_grid_z
+
+  ! Connectivity array of unstructured grid nodes.
+  function heat_grid_connectivity(self, grid_id, connectivity) &
+       result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    integer, intent (in) :: grid_id
+    integer, dimension(:), intent (out) :: connectivity
+    integer :: bmi_status
+
+    select case (grid_id)
+    case (1)
+       connectivity = [0]
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_grid_connectivity
+
+  ! Offsets of unstructured grid nodes.
+  function heat_grid_offset(self, grid_id, offset) &
+       result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    integer, intent (in) :: grid_id
+    integer, dimension(:), intent (out) :: offset
+    integer :: bmi_status
+
+    select case (grid_id)
+    case (1)
+       offset = [0]
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_grid_offset
 
   ! The data type of the variable, as a string.
   function heat_var_type(self, var_name, type) result (bmi_status)

--- a/heat/heatf.pc.cmake
+++ b/heat/heatf.pc.cmake
@@ -2,4 +2,4 @@ Name: heat
 Description: An example of the heat equation, with a BMI, in Fortran
 Version: ${HEAT_VERSION}
 Libs: -L${CMAKE_INSTALL_PREFIX}/lib -l${bmiheat_lib} -l${bmi_lib}
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include
+Cflags: -I${CMAKE_INSTALL_PREFIX}/include -std=f2003


### PR DESCRIPTION
The Fortran BMI bindings need to include the methods for unstructured grids. They include:

* get_grid_x
* get_grid_y
* get_grid_z
* get_grid_connectivity
* get_grid_offset

These are implemented in the sample *heat* model to support the `plate_surface__thermal_diffusivity` exchange item.

This PR partially addresses #6.
