### PR TITLE
Update get/set methods for diffusivity parameter

### DIFF
--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -295,7 +295,7 @@ contains
        shape = [self%model%n_y, self%model%n_x]
        bmi_status = BMI_SUCCESS
     case default
-       shape = [-1, -1]
+       shape = [-1]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_shape
@@ -349,6 +349,7 @@ contains
        origin = [0.0, 0.0]
        bmi_status = BMI_SUCCESS
     case default
+       origin = [-1.0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_origin
@@ -365,6 +366,7 @@ contains
        x = [0.0]
        bmi_status = BMI_SUCCESS
     case default
+       x = [-1.0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_x
@@ -381,6 +383,7 @@ contains
        y = [0.0]
        bmi_status = BMI_SUCCESS
     case default
+       y = [-1.0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_y
@@ -397,6 +400,7 @@ contains
        z = [0.0]
        bmi_status = BMI_SUCCESS
     case default
+       z = [-1.0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_z
@@ -414,6 +418,7 @@ contains
        connectivity = [0]
        bmi_status = BMI_SUCCESS
     case default
+       connectivity = [-1]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_connectivity
@@ -431,6 +436,7 @@ contains
        offset = [0]
        bmi_status = BMI_SUCCESS
     case default
+       offset = [-1]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_offset
@@ -444,6 +450,9 @@ contains
 
     select case (var_name)
     case ("plate_surface__temperature")
+       type = "real"
+       bmi_status = BMI_SUCCESS
+    case ("plate_surface__thermal_diffusivity")
        type = "real"
        bmi_status = BMI_SUCCESS
     case default
@@ -463,6 +472,9 @@ contains
     case ("plate_surface__temperature")
        units = "K"
        bmi_status = BMI_SUCCESS
+    case ("plate_surface__thermal_diffusivity")
+       units = "m2 s-1"
+       bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
@@ -479,6 +491,9 @@ contains
     select case (var_name)
     case ("plate_surface__temperature")
        size = sizeof(self%model%temperature(1,1))  ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case ("plate_surface__thermal_diffusivity")
+       size = sizeof(self%model%alpha)             ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -513,17 +528,23 @@ contains
     character (len=*), intent (in) :: var_name
     real, pointer, intent (inout) :: dest(:)
     integer :: bmi_status
-    integer :: n_elements
+    integer :: status, grid_id, grid_size
+
+    status = self%get_var_grid(var_name, grid_id)
+    status = self%get_grid_size(grid_id, grid_size)
 
     select case (var_name)
     case ("plate_surface__temperature")
-       n_elements = self%model%n_y * self%model%n_x
-       allocate(dest(n_elements))
-       dest = reshape(self%model%temperature, [n_elements])
+       allocate(dest(grid_size))
+       dest = reshape(self%model%temperature, [grid_size])
+       bmi_status = BMI_SUCCESS
+    case ("plate_surface__thermal_diffusivity")
+       allocate(dest(grid_size))
+       dest = [self%model%alpha]
        bmi_status = BMI_SUCCESS
     case default
-       n_elements = 1
-       allocate(dest(n_elements))
+       grid_size = 1
+       allocate(dest(grid_size))
        dest = -1.0
        bmi_status = BMI_FAILURE
     end select

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -607,6 +607,9 @@ contains
     case ("plate_surface__temperature")
        self%model%temperature = reshape(src, [self%model%n_y, self%model%n_x])
        bmi_status = BMI_SUCCESS
+    case ("plate_surface__thermal_diffusivity")
+       self%model%alpha = src(1)
+       bmi_status = BMI_SUCCESS
     case default
        bmi_status = BMI_FAILURE
     end select

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -43,6 +43,7 @@ module bmiheatf
      procedure :: get_value_at_indices => heat_get_at_indices
      procedure :: set_value => heat_set
      procedure :: set_value_at_indices => heat_set_at_indices
+     procedure :: print_model_info
   end type bmi_heat
 
   private :: heat_component_name, heat_input_var_names, heat_output_var_names
@@ -638,5 +639,12 @@ contains
        bmi_status = BMI_FAILURE
     end select
   end function heat_set_at_indices
+
+  ! A non-BMI procedure for model introspection.
+  subroutine print_model_info(self)
+    class (bmi_heat), intent (in) :: self
+
+    call print_info(self%model)
+  end subroutine print_model_info
 
 end module bmiheatf

--- a/heat/examples/CMakeLists.txt
+++ b/heat/examples/CMakeLists.txt
@@ -2,42 +2,25 @@ include(CTest)
 
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
-add_test(NAME info_ex COMMAND info_ex)
-set(src_info_ex info_ex.f90)
-add_executable(info_ex ${src_info_ex})
-target_link_libraries(info_ex ${bmi_lib} ${bmiheat_lib})
+function(make_example example_name)
+  add_test(NAME ${example_name} COMMAND ${example_name})
+  set(src_${example_name} ${example_name}.f90 testing_helpers.f90)
+  add_executable(${example_name} ${src_${example_name}})
+  target_link_libraries(${example_name} ${bmi_lib} ${bmiheat_lib})
+endfunction(make_example)
 
-add_test(NAME irf_ex COMMAND irf_ex)
-set(src_irf_ex irf_ex.f90)
-add_executable(irf_ex ${src_irf_ex})
-target_link_libraries(irf_ex ${bmi_lib} ${bmiheat_lib})
+make_example(info_ex)
+make_example(irf_ex)
+make_example(vargrid_ex)
+make_example(get_value_ex)
+make_example(set_value_ex)
+make_example(conflicting_instances_ex)
 
-add_test(NAME vargrid_ex COMMAND vargrid_ex)
-set(src_vargrid_ex vargrid_ex.f90)
-add_executable(vargrid_ex ${src_vargrid_ex})
-target_link_libraries(vargrid_ex ${bmi_lib} ${bmiheat_lib})
-
-add_test(NAME get_value_ex COMMAND get_value_ex)
-set(src_get_value_ex get_value_ex.f90 testing_helpers.f90)
-add_executable(get_value_ex ${src_get_value_ex})
-target_link_libraries(get_value_ex ${bmi_lib} ${bmiheat_lib})
-
-add_test(NAME set_value_ex COMMAND set_value_ex)
-set(src_set_value_ex set_value_ex.f90 testing_helpers.f90)
-add_executable(set_value_ex ${src_set_value_ex})
-target_link_libraries(set_value_ex ${bmi_lib} ${bmiheat_lib})
-
-add_test(
-  NAME conflicting_instances_ex
-  COMMAND conflicting_instances_ex)
-set(src_conflicting_instances_ex
-  conflicting_instances_ex.f90
-  testing_helpers.f90)
-add_executable(conflicting_instances_ex ${src_conflicting_instances_ex})
-target_link_libraries(conflicting_instances_ex ${bmi_lib} ${bmiheat_lib})
-file (
+file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test1.cfg
-  DESTINATION ${CMAKE_BINARY_DIR}/heat/examples)
-file (
+  DESTINATION ${CMAKE_BINARY_DIR}/heat/examples
+  )
+file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test2.cfg
-  DESTINATION ${CMAKE_BINARY_DIR}/heat/examples)
+  DESTINATION ${CMAKE_BINARY_DIR}/heat/examples
+  )

--- a/heat/examples/CMakeLists.txt
+++ b/heat/examples/CMakeLists.txt
@@ -15,6 +15,7 @@ make_example(vargrid_ex)
 make_example(get_value_ex)
 make_example(set_value_ex)
 make_example(conflicting_instances_ex)
+make_example(change_diffusivity_ex)
 
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test1.cfg

--- a/heat/examples/change_diffusivity_ex.f90
+++ b/heat/examples/change_diffusivity_ex.f90
@@ -1,0 +1,48 @@
+! See the effect of changing diffusivity on plate temperature.
+program change_diffusivity
+
+  use bmiheatf
+  use testing_helpers, only: print_array
+  implicit none
+
+  character (len=*), parameter :: config_file = "test1.cfg"
+  character (len=*), parameter :: &
+       dname = "plate_surface__thermal_diffusivity"
+  character (len=*), parameter :: &
+       tname = "plate_surface__temperature"
+  real, parameter :: end_time = 20.0
+
+  type (bmi_heat) :: m
+  integer :: tgrid_id
+  integer, dimension(2) :: tdims
+  real, pointer :: diffusivity(:), temperature(:)  
+  integer :: status
+  
+  ! Run model to the end with alpha=1.0 (from cfg file).
+  status = m%initialize(config_file)
+  status = m%get_var_grid(tname, tgrid_id)
+  status = m%get_grid_shape(tgrid_id, tdims)
+  status = m%get_value(dname, diffusivity)
+  status = m%update_until(end_time)
+  status = m%get_value(tname, temperature)
+  status = m%finalize()
+
+  write(*,"(a)") "Run 1"
+  write(*,"(a, f5.2)") "alpha =", diffusivity
+  call print_array(temperature, tdims)
+  
+  ! Run model to the end with alpha=0.75.
+  status = m%initialize(config_file)
+  diffusivity = 0.25
+  status = m%set_value(dname, diffusivity)
+  status = m%update_until(end_time)
+  status = m%get_value(tname, temperature)
+  status = m%finalize()
+
+  write(*,"(a)") "Run 2"
+  write(*,"(a, f5.2)") "alpha =", diffusivity
+  call print_array(temperature, tdims)
+
+  deallocate(diffusivity)
+  deallocate(temperature)
+end program change_diffusivity

--- a/heat/tests/test_get_value.f90
+++ b/heat/tests/test_get_value.f90
@@ -6,31 +6,37 @@ program test_get_value
   implicit none
 
   character (len=*), parameter :: config_file = "sample.cfg"
-  character (len=*), parameter :: var_name = "plate_surface__temperature"
-  integer, parameter :: rank = 2
-  integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
-  real, parameter, dimension(shape(2)) :: &
-       expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
+  type (bmi_heat) :: m
   integer :: retcode
 
-  retcode = run_test()
+  retcode = test1()
+  if (retcode.ne.BMI_SUCCESS) then
+     stop BMI_FAILURE
+  end if
+
+  retcode = test2()
   if (retcode.ne.BMI_SUCCESS) then
      stop BMI_FAILURE
   end if
 
 contains
 
-  function run_test() result(code)
-    type (bmi_heat) :: m
+  function test1() result(code)
+    character (len=*), parameter :: &
+         var_name = "plate_surface__temperature"
+    integer, parameter :: rank = 2
+    integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
+    real, parameter, dimension(shape(2)) :: &
+         expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
     real, pointer :: tval(:)
-    integer :: i
-    integer :: code
+    integer :: i, code
 
     status = m%initialize(config_file)
     status = m%get_value(var_name, tval)
     status = m%finalize()
 
     ! Visual inspection.
+    write(*,*) "Test 1"
     call print_array(tval, shape)
     do i = 1, shape(2)
        write(*,*) tval((i-1)*shape(1)+1)
@@ -45,6 +51,30 @@ contains
     end do
 
     deallocate(tval)
-  end function run_test
+  end function test1
 
+  function test2() result(code)
+    character (len=*), parameter :: &
+         var_name = "plate_surface__thermal_diffusivity"
+    real, parameter :: expected = 1.0
+    real, pointer :: val(:)
+    integer :: i, code
+
+    status = m%initialize(config_file)
+    status = m%get_value(var_name, val)
+    status = m%finalize()
+
+    ! Visual inspection.
+    write(*,*) "Test 2"
+    write(*,*) val
+    write(*,*) expected
+
+    code = BMI_SUCCESS
+    if (val(1).ne.expected) then
+       code = BMI_FAILURE
+    end if
+
+    deallocate(val)
+  end function test2
+  
 end program test_get_value

--- a/scripts/update_rpaths.sh
+++ b/scripts/update_rpaths.sh
@@ -15,6 +15,7 @@ if [[ -z "$CONDA_PREFIX" ]]; then
 fi
 
 examples="irf_ex \
+    change_diffusivity_ex \
     conflicting_instances_ex \
     get_value_ex \
     info_ex \


### PR DESCRIPTION
This PR updates the BMI methods

* `get_value`
* `set_value`

for the diffusivity parameter `plate_surface__thermal_diffusivity` for the *heat* model. It didn't make sense to update the other BMI getter/setter methods for this parameter.

The PR includes unit tests and an example of the effects of changing the diffusivity.