### PR TITLE
Make default visibility private in bmiheatf module

### DIFF
--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -48,8 +48,7 @@ module bmiheatf
 
   private
   public :: bmi_heat
-  public :: input_item_count, output_item_count, &
-       input_items, output_items, component_name
+  public :: input_items, output_items, component_name
 
   character (len=BMI_MAX_COMPONENT_NAME), target :: &
        component_name = "The 2D Heat Equation"

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -46,19 +46,10 @@ module bmiheatf
      procedure :: print_model_info
   end type bmi_heat
 
-  private :: heat_component_name, heat_input_var_names, heat_output_var_names
-  private :: heat_initialize, heat_finalize
-  private :: heat_start_time, heat_end_time, heat_current_time
-  private :: heat_time_step, heat_time_units
-  private :: heat_update, heat_update_frac, heat_update_until
-  private :: heat_var_grid
-  private :: heat_grid_type, heat_grid_rank, heat_grid_shape
-  private :: heat_grid_size, heat_grid_spacing, heat_grid_origin
-  private :: heat_grid_x, heat_grid_y, heat_grid_z
-  private :: heat_grid_connectivity, heat_grid_offset
-  private :: heat_var_type, heat_var_units, heat_var_itemsize, heat_var_nbytes
-  private :: heat_get, heat_get_ref, heat_get_at_indices
-  private :: heat_set, heat_set_at_indices
+  private
+  public :: bmi_heat
+  public :: input_item_count, output_item_count, &
+       input_items, output_items, component_name
 
   character (len=BMI_MAX_COMPONENT_NAME), target :: &
        component_name = "The 2D Heat Equation"

--- a/heat/examples/conflicting_instances_ex.f90
+++ b/heat/examples/conflicting_instances_ex.f90
@@ -1,6 +1,7 @@
 ! Do two instances of bmi_heat conflict?
 program conflicting_instances_test
 
+  use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/heat/examples/get_value_ex.f90
+++ b/heat/examples/get_value_ex.f90
@@ -1,6 +1,7 @@
 ! Test the get_value, get_value_ref, and get_value_at_indices functions.
 program get_value_test
 
+  use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/heat/examples/info_ex.f90
+++ b/heat/examples/info_ex.f90
@@ -17,7 +17,7 @@ program info_test
 
   s = m%get_input_var_names(names)
   write (*,"(a30)") "Input variables: "
-  do i = 1, input_item_count
+  do i = 1, size(names)
      write (*,"(a30, a40)") "- ", names(i)
   end do
   s = m%get_output_var_names(names)

--- a/heat/examples/info_ex.f90
+++ b/heat/examples/info_ex.f90
@@ -1,6 +1,7 @@
 ! Test the basic info BMI methods.
 program info_test
 
+  use bmif
   use bmiheatf
   implicit none
 

--- a/heat/examples/irf_ex.f90
+++ b/heat/examples/irf_ex.f90
@@ -1,6 +1,7 @@
 ! Test the lifecycle and time BMI methods.
 program irf_test
 
+  use bmif, only: BMI_MAX_UNITS_NAME
   use bmiheatf
   implicit none
 

--- a/heat/examples/set_value_ex.f90
+++ b/heat/examples/set_value_ex.f90
@@ -1,6 +1,7 @@
 ! Test the set_value and set_value_at_indices functions.
 program set_value_test
 
+  use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
   use testing_helpers
   implicit none

--- a/heat/examples/vargrid_ex.f90
+++ b/heat/examples/vargrid_ex.f90
@@ -1,6 +1,7 @@
 ! Test the BMI get_var_* and get_grid_* functions.
 program vargrid_test
 
+  use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
   implicit none
 

--- a/heat/tests/test_by_reference.f90
+++ b/heat/tests/test_by_reference.f90
@@ -1,5 +1,6 @@
 program test_by_reference
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_finalize.f90
+++ b/heat/tests/test_finalize.f90
@@ -1,5 +1,6 @@
 program test_finalize
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, config_file
 
@@ -11,6 +12,6 @@ program test_finalize
   status = m%initialize(config_file)
   status1 = m%finalize()
   if (status1.ne.BMI_SUCCESS) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_finalize

--- a/heat/tests/test_get_component_name.f90
+++ b/heat/tests/test_get_component_name.f90
@@ -1,5 +1,6 @@
 program test_get_component_name
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_COMPONENT_NAME
   use bmiheatf
   use fixtures, only: status
 
@@ -11,6 +12,6 @@ program test_get_component_name
   status = m%get_component_name(name)
 
   if (name.ne.component_name) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_component_name

--- a/heat/tests/test_get_current_time.f90
+++ b/heat/tests/test_get_current_time.f90
@@ -1,5 +1,6 @@
 program test_get_current_time
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -15,6 +16,6 @@ program test_get_current_time
   status = m%finalize()
 
   if (current_time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_current_time

--- a/heat/tests/test_get_end_time.f90
+++ b/heat/tests/test_get_end_time.f90
@@ -1,5 +1,6 @@
 program test_get_end_time
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -15,6 +16,6 @@ program test_get_end_time
   status = m%finalize()
 
   if (end_time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_end_time

--- a/heat/tests/test_get_grid_connectivity.f90
+++ b/heat/tests/test_get_grid_connectivity.f90
@@ -1,5 +1,6 @@
 program test_get_grid_connectivity
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -23,7 +24,7 @@ program test_get_grid_connectivity
 
   do i = 1, nconnectivity
      if (grid_connectivity(i).ne.expected_connectivity(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_connectivity

--- a/heat/tests/test_get_grid_offset.f90
+++ b/heat/tests/test_get_grid_offset.f90
@@ -1,5 +1,6 @@
 program test_get_grid_offset
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -22,7 +23,7 @@ program test_get_grid_offset
 
   do i = 1, noffset
      if (grid_offset(i).ne.expected_offset(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_offset

--- a/heat/tests/test_get_grid_origin.f90
+++ b/heat/tests/test_get_grid_origin.f90
@@ -1,5 +1,6 @@
 program test_get_grid_origin
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -19,7 +20,7 @@ program test_get_grid_origin
 
   do i = 1, rank
      if (grid_origin(i).ne.expected_origin(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_origin

--- a/heat/tests/test_get_grid_rank.f90
+++ b/heat/tests/test_get_grid_rank.f90
@@ -1,5 +1,6 @@
 program test_get_grid_rank
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_grid_rank
   status = m%finalize()
 
   if (grid_rank.ne.expected_rank) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_grid_rank

--- a/heat/tests/test_get_grid_shape.f90
+++ b/heat/tests/test_get_grid_shape.f90
@@ -1,5 +1,6 @@
 program test_get_grid_shape
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -19,7 +20,7 @@ program test_get_grid_shape
 
   do i = 1, rank
      if (grid_shape(i).ne.expected_shape(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_shape

--- a/heat/tests/test_get_grid_size.f90
+++ b/heat/tests/test_get_grid_size.f90
@@ -1,5 +1,6 @@
 program test_get_grid_size
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_grid_size
   status = m%finalize()
 
   if (grid_size.ne.expected_size) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_grid_size

--- a/heat/tests/test_get_grid_spacing.f90
+++ b/heat/tests/test_get_grid_spacing.f90
@@ -1,5 +1,6 @@
 program test_get_grid_spacing
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -19,7 +20,7 @@ program test_get_grid_spacing
 
   do i = 1, rank
      if (grid_spacing(i).ne.expected_spacing(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_spacing

--- a/heat/tests/test_get_grid_type.f90
+++ b/heat/tests/test_get_grid_type.f90
@@ -1,5 +1,6 @@
 program test_get_grid_type
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -17,6 +18,6 @@ program test_get_grid_type
   status = m%finalize()
 
   if (grid_type.ne.expected_type) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_grid_type

--- a/heat/tests/test_get_grid_x.f90
+++ b/heat/tests/test_get_grid_x.f90
@@ -1,5 +1,6 @@
 program test_get_grid_x
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -22,7 +23,7 @@ program test_get_grid_x
 
   do i = 1, nx
      if (grid_x(i).ne.expected_x(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_x

--- a/heat/tests/test_get_grid_y.f90
+++ b/heat/tests/test_get_grid_y.f90
@@ -1,5 +1,6 @@
 program test_get_grid_y
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -22,7 +23,7 @@ program test_get_grid_y
 
   do i = 1, ny
      if (grid_y(i).ne.expected_y(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_y

--- a/heat/tests/test_get_grid_z.f90
+++ b/heat/tests/test_get_grid_z.f90
@@ -1,5 +1,6 @@
 program test_get_grid_z
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -22,7 +23,7 @@ program test_get_grid_z
 
   do i = 1, nz
      if (grid_z(i).ne.expected_z(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_grid_z

--- a/heat/tests/test_get_input_var_names.f90
+++ b/heat/tests/test_get_input_var_names.f90
@@ -12,7 +12,7 @@ program test_get_input_var_names
   
   status = m%get_input_var_names(names)
   
-  do i=1, input_item_count
+  do i=1, size(names)
      if (names(i).ne.input_items(i)) then
         stop BMI_FAILURE
      end if

--- a/heat/tests/test_get_input_var_names.f90
+++ b/heat/tests/test_get_input_var_names.f90
@@ -1,5 +1,6 @@
 program test_get_input_var_names
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmiheatf
   use fixtures, only: status
 
@@ -13,7 +14,7 @@ program test_get_input_var_names
   
   do i=1, input_item_count
      if (names(i).ne.input_items(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_input_var_names

--- a/heat/tests/test_get_output_var_names.f90
+++ b/heat/tests/test_get_output_var_names.f90
@@ -12,7 +12,7 @@ program test_get_output_var_names
   
   status = m%get_output_var_names(names)
   
-  do i=1, output_item_count
+  do i=1, size(names)
      if (names(i).ne.output_items(i)) then
         stop BMI_FAILURE
      end if

--- a/heat/tests/test_get_output_var_names.f90
+++ b/heat/tests/test_get_output_var_names.f90
@@ -1,5 +1,6 @@
 program test_get_output_var_names
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_VAR_NAME
   use bmiheatf
   use fixtures, only: status
 
@@ -13,7 +14,7 @@ program test_get_output_var_names
   
   do i=1, output_item_count
      if (names(i).ne.output_items(i)) then
-        stop 1
+        stop BMI_FAILURE
      end if
   end do
 end program test_get_output_var_names

--- a/heat/tests/test_get_start_time.f90
+++ b/heat/tests/test_get_start_time.f90
@@ -1,5 +1,6 @@
 program test_get_start_time
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -15,6 +16,6 @@ program test_get_start_time
   status = m%finalize()
 
   if (start_time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_start_time

--- a/heat/tests/test_get_time_step.f90
+++ b/heat/tests/test_get_time_step.f90
@@ -1,5 +1,6 @@
 program test_get_time_step
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -15,6 +16,6 @@ program test_get_time_step
   status = m%finalize()
 
   if (time_step.ne.expected_time_step) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_time_step

--- a/heat/tests/test_get_time_units.f90
+++ b/heat/tests/test_get_time_units.f90
@@ -1,5 +1,6 @@
 program test_get_time_units
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -15,6 +16,6 @@ program test_get_time_units
   status = m%finalize()
 
   if (units.ne.expected_units) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_time_units

--- a/heat/tests/test_get_value.f90
+++ b/heat/tests/test_get_value.f90
@@ -1,5 +1,6 @@
 program test_get_value
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_get_value_at_indices.f90
+++ b/heat/tests/test_get_value_at_indices.f90
@@ -1,5 +1,6 @@
 program test_get_value_at_indices
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_get_value_ref.f90
+++ b/heat/tests/test_get_value_ref.f90
@@ -1,5 +1,6 @@
 program test_get_value_ref
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_get_var_grid.f90
+++ b/heat/tests/test_get_var_grid.f90
@@ -1,5 +1,6 @@
 program test_get_var_grid
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_var_grid
   status = m%finalize()
 
   if (grid_id.ne.expected_id) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_var_grid

--- a/heat/tests/test_get_var_itemsize.f90
+++ b/heat/tests/test_get_var_itemsize.f90
@@ -1,5 +1,6 @@
 program test_get_var_itemsize
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_var_itemsize
   status = m%finalize()
 
   if (item_size.ne.expected_size) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_var_itemsize

--- a/heat/tests/test_get_var_nbytes.f90
+++ b/heat/tests/test_get_var_nbytes.f90
@@ -1,5 +1,6 @@
 program test_get_var_nbytes
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_var_nbytes
   status = m%finalize()
 
   if (var_nbytes.ne.expected_nbytes) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_var_nbytes

--- a/heat/tests/test_get_var_type.f90
+++ b/heat/tests/test_get_var_type.f90
@@ -1,5 +1,6 @@
 program test_get_var_type
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_TYPE_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_var_type
   status = m%finalize()
 
   if (var_type.ne.expected_type) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_var_type

--- a/heat/tests/test_get_var_units.f90
+++ b/heat/tests/test_get_var_units.f90
@@ -1,5 +1,6 @@
 program test_get_var_units
 
+  use bmif, only: BMI_FAILURE, BMI_MAX_UNITS_NAME
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_get_var_units
   status = m%finalize()
 
   if (var_units.ne.expected_units) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_get_var_units

--- a/heat/tests/test_initialize.f90
+++ b/heat/tests/test_initialize.f90
@@ -1,5 +1,6 @@
 program test_initialize
 
+  use bmif, only: BMI_SUCCESS
   use bmiheatf
   use fixtures, only: status
 

--- a/heat/tests/test_set_value.f90
+++ b/heat/tests/test_set_value.f90
@@ -1,5 +1,6 @@
 program test_set_value
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_set_value_at_indices.f90
+++ b/heat/tests/test_set_value_at_indices.f90
@@ -1,5 +1,6 @@
 program test_set_value_at_indices
 
+  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use bmiheatf
   use fixtures, only: status, print_array
 

--- a/heat/tests/test_update.f90
+++ b/heat/tests/test_update.f90
@@ -1,5 +1,6 @@
 program test_update
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_update
   status = m%finalize()
 
   if (time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_update

--- a/heat/tests/test_update_frac.f90
+++ b/heat/tests/test_update_frac.f90
@@ -1,5 +1,6 @@
 program test_update_frac
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_update_frac
   status = m%finalize()
 
   if (time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_update_frac

--- a/heat/tests/test_update_until.f90
+++ b/heat/tests/test_update_until.f90
@@ -1,5 +1,6 @@
 program test_update_until
 
+  use bmif, only: BMI_FAILURE
   use bmiheatf
   use fixtures, only: config_file, status
 
@@ -16,6 +17,6 @@ program test_update_until
   status = m%finalize()
 
   if (time.ne.expected_time) then
-     stop 1
+     stop BMI_FAILURE
   end if
 end program test_update_until


### PR DESCRIPTION
Formerly, everything in the module was public, by default, and I explicitly set individual items private. It's a better Fortran programming practice to make everything private by default, then explicitly set items that need to be exposed outside the module as public.

This also cleans up the definition of the *bmiheatf* module.