### PR TITLE
Use generic procedures for BMI getters and setters

### DIFF
--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -56,7 +56,12 @@ module bmif
        procedure (bmif_set_value_int), deferred :: set_value_int
        procedure (bmif_set_value_float), deferred :: set_value_float
        procedure (bmif_set_value_double), deferred :: set_value_double
-       procedure (bmif_set_value_at_indices), deferred :: set_value_at_indices
+       procedure (bmif_set_value_at_indices_int), deferred :: &
+            set_value_at_indices_int
+       procedure (bmif_set_value_at_indices_float), deferred :: &
+            set_value_at_indices_float
+       procedure (bmif_set_value_at_indices_double), deferred :: &
+            set_value_at_indices_double
   end type bmi
 
   abstract interface
@@ -426,15 +431,38 @@ module bmif
        integer :: bmi_status
      end function bmif_set_value_double
 
-     ! Set values at particular (one-dimensional) indices.
-     function bmif_set_value_at_indices(self, var_name, indices, src) result (bmi_status)
+     ! Set integer values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_int(self, var_name, indices, src) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (inout) :: self
+       character (len=*), intent (in) :: var_name
+       integer, intent (in) :: indices(:)
+       integer, intent (in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_int
+
+     ! Set real values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_float(self, var_name, indices, src) &
+          result (bmi_status)
        import :: bmi
        class (bmi), intent (inout) :: self
        character (len=*), intent (in) :: var_name
        integer, intent (in) :: indices(:)
        real, intent (in) :: src(:)
        integer :: bmi_status
-     end function bmif_set_value_at_indices
+     end function bmif_set_value_at_indices_float
+
+     ! Set double values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_double(self, var_name, indices, src) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (inout) :: self
+       character (len=*), intent (in) :: var_name
+       integer, intent (in) :: indices(:)
+       double precision, intent (in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_double
 
   end interface
 

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -41,7 +41,9 @@ module bmif
        procedure (bmif_get_var_units), deferred :: get_var_units
        procedure (bmif_get_var_itemsize), deferred :: get_var_itemsize
        procedure (bmif_get_var_nbytes), deferred :: get_var_nbytes
-       procedure (bmif_get_value), deferred :: get_value
+       procedure (bmif_get_value_int), deferred :: get_value_int
+       procedure (bmif_get_value_float), deferred :: get_value_float
+       procedure (bmif_get_value_double), deferred :: get_value_double
        procedure (bmif_get_value_ref), deferred :: get_value_ref
        procedure (bmif_get_value_at_indices), deferred :: get_value_at_indices
        procedure (bmif_set_value), deferred :: set_value
@@ -298,14 +300,32 @@ module bmif
        integer :: bmi_status
      end function bmif_get_var_nbytes
 
-     ! Get a copy of values (flattened!) of the given variable.
-     function bmif_get_value(self, var_name, dest) result (bmi_status)
+     ! Get a copy of values (flattened!) of the given integer variable.
+     function bmif_get_value_int(self, var_name, dest) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       integer, pointer, intent (inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_int
+
+     ! Get a copy of values (flattened!) of the given real variable.
+     function bmif_get_value_float(self, var_name, dest) result (bmi_status)
        import :: bmi
        class (bmi), intent (in) :: self
        character (len=*), intent (in) :: var_name
        real, pointer, intent (inout) :: dest(:)
        integer :: bmi_status
-     end function bmif_get_value
+     end function bmif_get_value_float
+
+     ! Get a copy of values (flattened!) of the given double variable.
+     function bmif_get_value_double(self, var_name, dest) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       double precision, pointer, intent (inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_double
 
      ! Get a reference to the values (flattened!) of the given variable.
      function bmif_get_value_ref(self, var_name, dest) result (bmi_status)

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -44,8 +44,15 @@ module bmif
        procedure (bmif_get_value_int), deferred :: get_value_int
        procedure (bmif_get_value_float), deferred :: get_value_float
        procedure (bmif_get_value_double), deferred :: get_value_double
-       procedure (bmif_get_value_ref), deferred :: get_value_ref
-       procedure (bmif_get_value_at_indices), deferred :: get_value_at_indices
+       procedure (bmif_get_value_ref_int), deferred :: get_value_ref_int
+       procedure (bmif_get_value_ref_float), deferred :: get_value_ref_float
+       procedure (bmif_get_value_ref_double), deferred :: get_value_ref_double
+       procedure (bmif_get_value_at_indices_int), deferred :: &
+            get_value_at_indices_int
+       procedure (bmif_get_value_at_indices_float), deferred :: &
+            get_value_at_indices_float
+       procedure (bmif_get_value_at_indices_double), deferred :: &
+            get_value_at_indices_double
        procedure (bmif_set_value), deferred :: set_value
        procedure (bmif_set_value_at_indices), deferred :: set_value_at_indices
   end type bmi
@@ -327,24 +334,68 @@ module bmif
        integer :: bmi_status
      end function bmif_get_value_double
 
-     ! Get a reference to the values (flattened!) of the given variable.
-     function bmif_get_value_ref(self, var_name, dest) result (bmi_status)
+     ! Get a reference to the given integer variable.
+     function bmif_get_value_ref_int(self, var_name, dest) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       integer, pointer, intent (inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_ref_int
+
+     ! Get a reference to the given real variable.
+     function bmif_get_value_ref_float(self, var_name, dest) &
+          result (bmi_status)
        import :: bmi
        class (bmi), intent (in) :: self
        character (len=*), intent (in) :: var_name
        real, pointer, intent (inout) :: dest(:)
        integer :: bmi_status
-     end function bmif_get_value_ref
+     end function bmif_get_value_ref_float
 
-     ! Get values at particular (one-dimensional) indices.
-     function bmif_get_value_at_indices(self, var_name, dest, indices) result (bmi_status)
+     ! Get a reference to the given double variable.
+     function bmif_get_value_ref_double(self, var_name, dest) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       double precision, pointer, intent (inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_ref_double
+
+     ! Get integer values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_int(self, var_name, dest, indices) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       integer, pointer, intent (inout) :: dest(:)
+       integer, intent (in) :: indices(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_int
+
+     ! Get real values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_float(self, var_name, dest, indices) &
+          result (bmi_status)
        import :: bmi
        class (bmi), intent (in) :: self
        character (len=*), intent (in) :: var_name
        real, pointer, intent (inout) :: dest(:)
        integer, intent (in) :: indices(:)
        integer :: bmi_status
-     end function bmif_get_value_at_indices
+     end function bmif_get_value_at_indices_float
+
+     ! Get double values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_double(self, var_name, dest, indices) &
+          result (bmi_status)
+       import :: bmi
+       class (bmi), intent (in) :: self
+       character (len=*), intent (in) :: var_name
+       double precision, pointer, intent (inout) :: dest(:)
+       integer, intent (in) :: indices(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_double
 
      ! Set a new value for a model variable.
      function bmif_set_value(self, var_name, src) result (bmi_status)

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -53,7 +53,9 @@ module bmif
             get_value_at_indices_float
        procedure (bmif_get_value_at_indices_double), deferred :: &
             get_value_at_indices_double
-       procedure (bmif_set_value), deferred :: set_value
+       procedure (bmif_set_value_int), deferred :: set_value_int
+       procedure (bmif_set_value_float), deferred :: set_value_float
+       procedure (bmif_set_value_double), deferred :: set_value_double
        procedure (bmif_set_value_at_indices), deferred :: set_value_at_indices
   end type bmi
 
@@ -397,14 +399,32 @@ module bmif
        integer :: bmi_status
      end function bmif_get_value_at_indices_double
 
-     ! Set a new value for a model variable.
-     function bmif_set_value(self, var_name, src) result (bmi_status)
+     ! Set new values for an integer model variable.
+     function bmif_set_value_int(self, var_name, src) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (inout) :: self
+       character (len=*), intent (in) :: var_name
+       integer, intent (in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_int
+
+     ! Set new values for a real model variable.
+     function bmif_set_value_float(self, var_name, src) result (bmi_status)
        import :: bmi
        class (bmi), intent (inout) :: self
        character (len=*), intent (in) :: var_name
        real, intent (in) :: src(:)
        integer :: bmi_status
-     end function bmif_set_value
+     end function bmif_set_value_float
+
+     ! Set new values for a double model variable.
+     function bmif_set_value_double(self, var_name, src) result (bmi_status)
+       import :: bmi
+       class (bmi), intent (inout) :: self
+       character (len=*), intent (in) :: var_name
+       double precision, intent (in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_double
 
      ! Set values at particular (one-dimensional) indices.
      function bmif_set_value_at_indices(self, var_name, indices, src) result (bmi_status)

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -38,7 +38,10 @@ module bmiheatf
      procedure :: get_var_units => heat_var_units
      procedure :: get_var_itemsize => heat_var_itemsize
      procedure :: get_var_nbytes => heat_var_nbytes
-     procedure :: get_value => heat_get
+     procedure :: get_value_int => heat_get_int
+     procedure :: get_value_float => heat_get_float
+     procedure :: get_value_double => heat_get_double
+     generic :: get_value => get_value_int, get_value_float, get_value_double
      procedure :: get_value_ref => heat_get_ref
      procedure :: get_value_at_indices => heat_get_at_indices
      procedure :: set_value => heat_set
@@ -513,8 +516,28 @@ contains
     end if
   end function heat_var_nbytes
 
-  ! Get a copy of a variable's values, flattened.
-  function heat_get(self, var_name, dest) result (bmi_status)
+  ! Get a copy of a integer variable's values, flattened.
+  function heat_get_int(self, var_name, dest) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    integer, pointer, intent (inout) :: dest(:)
+    integer :: bmi_status
+    integer :: status, grid_id, grid_size
+
+    status = self%get_var_grid(var_name, grid_id)
+    status = self%get_grid_size(grid_id, grid_size)
+
+    select case (var_name)
+    case default
+       grid_size = 1
+       allocate(dest(grid_size))
+       dest = -1
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_int
+
+  ! Get a copy of a real variable's values, flattened.
+  function heat_get_float(self, var_name, dest) result (bmi_status)
     class (bmi_heat), intent (in) :: self
     character (len=*), intent (in) :: var_name
     real, pointer, intent (inout) :: dest(:)
@@ -539,7 +562,27 @@ contains
        dest = -1.0
        bmi_status = BMI_FAILURE
     end select
-  end function heat_get
+  end function heat_get_float
+
+  ! Get a copy of a double variable's values, flattened.
+  function heat_get_double(self, var_name, dest) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    double precision, pointer, intent (inout) :: dest(:)
+    integer :: bmi_status
+    integer :: status, grid_id, grid_size
+
+    status = self%get_var_grid(var_name, grid_id)
+    status = self%get_grid_size(grid_id, grid_size)
+
+    select case (var_name)
+    case default
+       grid_size = 1
+       allocate(dest(grid_size))
+       dest = -1.d0
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_double
 
   ! Get a reference to a variable's values, flattened.
   function heat_get_ref(self, var_name, dest) result (bmi_status)

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -41,21 +41,31 @@ module bmiheatf
      procedure :: get_value_int => heat_get_int
      procedure :: get_value_float => heat_get_float
      procedure :: get_value_double => heat_get_double
-     generic :: get_value => get_value_int, get_value_float, get_value_double
+     generic :: get_value => &
+          get_value_int, &
+          get_value_float, &
+          get_value_double
      procedure :: get_value_ref_int => heat_get_ref_int
      procedure :: get_value_ref_float => heat_get_ref_float
      procedure :: get_value_ref_double => heat_get_ref_double
-     generic :: get_value_ref => get_value_ref_int, get_value_ref_float, &
+     generic :: get_value_ref => &
+          get_value_ref_int, &
+          get_value_ref_float, &
           get_value_ref_double
-
-     ! procedure :: get_value_at_indices => heat_get_at_indices
      procedure :: get_value_at_indices_int => heat_get_at_indices_int
      procedure :: get_value_at_indices_float => heat_get_at_indices_float
      procedure :: get_value_at_indices_double => heat_get_at_indices_double
-     generic :: get_value_at_indices => get_value_at_indices_int, &
-          get_value_at_indices_float, get_value_at_indices_double
-
-     procedure :: set_value => heat_set
+     generic :: get_value_at_indices => &
+          get_value_at_indices_int, &
+          get_value_at_indices_float, &
+          get_value_at_indices_double
+     procedure :: set_value_int => heat_set_int
+     procedure :: set_value_float => heat_set_float
+     procedure :: set_value_double => heat_set_double
+     generic :: set_value => &
+          set_value_int, &
+          set_value_float, &
+          set_value_double
      procedure :: set_value_at_indices => heat_set_at_indices
      procedure :: print_model_info
   end type bmi_heat
@@ -725,8 +735,24 @@ contains
     end select
   end function heat_get_at_indices_double
 
-  ! Set new values.
-  function heat_set(self, var_name, src) result (bmi_status)
+  ! Set new integer values.
+  function heat_set_int(self, var_name, src) result (bmi_status)
+    class (bmi_heat), intent (inout) :: self
+    character (len=*), intent (in) :: var_name
+    integer, intent (in) :: src(:)
+    integer :: bmi_status
+
+    select case (var_name)
+    case ("model__identification_number")
+       self%model%id = src(1)
+       bmi_status = BMI_SUCCESS
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_set_int
+
+  ! Set new real values.
+  function heat_set_float(self, var_name, src) result (bmi_status)
     class (bmi_heat), intent (inout) :: self
     character (len=*), intent (in) :: var_name
     real, intent (in) :: src(:)
@@ -742,7 +768,20 @@ contains
     case default
        bmi_status = BMI_FAILURE
     end select
-  end function heat_set
+  end function heat_set_float
+
+  ! Set new double values.
+  function heat_set_double(self, var_name, src) result (bmi_status)
+    class (bmi_heat), intent (inout) :: self
+    character (len=*), intent (in) :: var_name
+    double precision, intent (in) :: src(:)
+    integer :: bmi_status
+
+    select case (var_name)
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_set_double
 
   ! Set new values at particular locations.
   function heat_set_at_indices(self, var_name, indices, src) result (bmi_status)

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -57,7 +57,7 @@ module bmiheatf
        component_name = "The 2D Heat Equation"
 
   ! Exchange items
-  integer, parameter :: input_item_count = 2
+  integer, parameter :: input_item_count = 3
   integer, parameter :: output_item_count = 1
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension (input_item_count) :: input_items
@@ -85,6 +85,7 @@ contains
 
     input_items(1) = 'plate_surface__temperature'
     input_items(2) = 'plate_surface__thermal_diffusivity'
+    input_items(3) = 'model__identification_number'
 
     names => input_items
     bmi_status = BMI_SUCCESS
@@ -229,6 +230,9 @@ contains
        grid_id = 0
        bmi_status = BMI_SUCCESS
     case ('plate_surface__thermal_diffusivity')
+       grid_id = 1
+       bmi_status = BMI_SUCCESS
+    case ('model__identification_number')
        grid_id = 1
        bmi_status = BMI_SUCCESS
     case default
@@ -449,6 +453,9 @@ contains
     case ("plate_surface__thermal_diffusivity")
        type = "real"
        bmi_status = BMI_SUCCESS
+    case ("model__identification_number")
+       type = "integer"
+       bmi_status = BMI_SUCCESS
     case default
        type = "-"
        bmi_status = BMI_FAILURE
@@ -469,6 +476,9 @@ contains
     case ("plate_surface__thermal_diffusivity")
        units = "m2 s-1"
        bmi_status = BMI_SUCCESS
+    case ("model__identification_number")
+       units = "-"
+       bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
@@ -488,6 +498,9 @@ contains
        bmi_status = BMI_SUCCESS
     case ("plate_surface__thermal_diffusivity")
        size = sizeof(self%model%alpha)             ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
+    case ("model__identification_number")
+       size = sizeof(self%model%id)                ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -528,6 +541,10 @@ contains
     status = self%get_grid_size(grid_id, grid_size)
 
     select case (var_name)
+    case ("model__identification_number")
+       allocate(dest(grid_size))
+       dest = [self%model%id]
+       bmi_status = BMI_SUCCESS
     case default
        grid_size = 1
        allocate(dest(grid_size))

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -42,8 +42,19 @@ module bmiheatf
      procedure :: get_value_float => heat_get_float
      procedure :: get_value_double => heat_get_double
      generic :: get_value => get_value_int, get_value_float, get_value_double
-     procedure :: get_value_ref => heat_get_ref
-     procedure :: get_value_at_indices => heat_get_at_indices
+     procedure :: get_value_ref_int => heat_get_ref_int
+     procedure :: get_value_ref_float => heat_get_ref_float
+     procedure :: get_value_ref_double => heat_get_ref_double
+     generic :: get_value_ref => get_value_ref_int, get_value_ref_float, &
+          get_value_ref_double
+
+     ! procedure :: get_value_at_indices => heat_get_at_indices
+     procedure :: get_value_at_indices_int => heat_get_at_indices_int
+     procedure :: get_value_at_indices_float => heat_get_at_indices_float
+     procedure :: get_value_at_indices_double => heat_get_at_indices_double
+     generic :: get_value_at_indices => get_value_at_indices_int, &
+          get_value_at_indices_float, get_value_at_indices_double
+
      procedure :: set_value => heat_set
      procedure :: set_value_at_indices => heat_set_at_indices
      procedure :: print_model_info
@@ -601,8 +612,23 @@ contains
     end select
   end function heat_get_double
 
-  ! Get a reference to a variable's values, flattened.
-  function heat_get_ref(self, var_name, dest) result (bmi_status)
+  ! Get a reference to an integer-valued variable, flattened.
+  function heat_get_ref_int(self, var_name, dest) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    integer, pointer, intent (inout) :: dest(:)
+    integer :: bmi_status
+    type (c_ptr) :: src
+    integer :: n_elements
+
+    select case (var_name)
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_ref_int
+
+  ! Get a reference to a real-valued variable, flattened.
+  function heat_get_ref_float(self, var_name, dest) result (bmi_status)
     class (bmi_heat), intent (in) :: self
     character (len=*), intent (in) :: var_name
     real, pointer, intent (inout) :: dest(:)
@@ -612,17 +638,51 @@ contains
 
     select case (var_name)
     case ("plate_surface__temperature")
-       src = c_loc (self%model%temperature(1,1))
+       src = c_loc(self%model%temperature(1,1))
        n_elements = self%model%n_y * self%model%n_x
        call c_f_pointer(src, dest, [n_elements])
        bmi_status = BMI_SUCCESS
     case default
        bmi_status = BMI_FAILURE
     end select
-  end function heat_get_ref
+  end function heat_get_ref_float
 
-  ! Get values of a variable at the given locations.
-  function heat_get_at_indices(self, var_name, dest, indices) result (bmi_status)
+  ! Get a reference to an double-valued variable, flattened.
+  function heat_get_ref_double(self, var_name, dest) result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    double precision, pointer, intent (inout) :: dest(:)
+    integer :: bmi_status
+    type (c_ptr) :: src
+    integer :: n_elements
+
+    select case (var_name)
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_ref_double
+
+  ! Get values of an integer variable at the given locations.
+  function heat_get_at_indices_int(self, var_name, dest, indices) &
+       result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    integer, pointer, intent (inout) :: dest(:)
+    integer, intent (in) :: indices(:)
+    integer :: bmi_status
+    type (c_ptr) src
+    integer, pointer :: src_flattened(:)
+    integer :: i, n_elements
+
+    select case (var_name)
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_at_indices_int
+
+  ! Get values of a real variable at the given locations.
+  function heat_get_at_indices_float(self, var_name, dest, indices) &
+       result (bmi_status)
     class (bmi_heat), intent (in) :: self
     character (len=*), intent (in) :: var_name
     real, pointer, intent (inout) :: dest(:)
@@ -634,7 +694,7 @@ contains
 
     select case (var_name)
     case ("plate_surface__temperature")
-       src = c_loc (self%model%temperature(1,1))
+       src = c_loc(self%model%temperature(1,1))
        call c_f_pointer(src, src_flattened, [self%model%n_y * self%model%n_x])
        n_elements = size (indices)
        allocate(dest(n_elements))
@@ -645,7 +705,25 @@ contains
     case default
        bmi_status = BMI_FAILURE
     end select
-  end function heat_get_at_indices
+  end function heat_get_at_indices_float
+
+  ! Get values of a double variable at the given locations.
+  function heat_get_at_indices_double(self, var_name, dest, indices) &
+       result (bmi_status)
+    class (bmi_heat), intent (in) :: self
+    character (len=*), intent (in) :: var_name
+    double precision, pointer, intent (inout) :: dest(:)
+    integer, intent (in) :: indices(:)
+    integer :: bmi_status
+    type (c_ptr) src
+    double precision, pointer :: src_flattened(:)
+    integer :: i, n_elements
+
+    select case (var_name)
+    case default
+       bmi_status = BMI_FAILURE
+    end select
+  end function heat_get_at_indices_double
 
   ! Set new values.
   function heat_set(self, var_name, src) result (bmi_status)

--- a/heat/heat.f90
+++ b/heat/heat.f90
@@ -5,6 +5,8 @@ module heatf
 
   ! Define the attributes of the model.
   type :: heat_model
+     integer :: id
+
      real :: dt
      real :: t
      real :: t_end
@@ -51,6 +53,7 @@ contains
   subroutine initialize(model)
     type (heat_model), intent (inout) :: model
 
+    model%id = 0
     model%t = 0.
     model%dt = 1.
     model%dx = 1.

--- a/heat/tests/test_get_value.f90
+++ b/heat/tests/test_get_value.f90
@@ -20,8 +20,14 @@ program test_get_value
      stop BMI_FAILURE
   end if
 
+  retcode = test3()
+  if (retcode.ne.BMI_SUCCESS) then
+     stop BMI_FAILURE
+  end if
+
 contains
 
+  ! Test getting plate_surface__temperature.
   function test1() result(code)
     character (len=*), parameter :: &
          var_name = "plate_surface__temperature"
@@ -54,6 +60,7 @@ contains
     deallocate(tval)
   end function test1
 
+  ! Test getting plate_surface__thermal_diffusivity.
   function test2() result(code)
     character (len=*), parameter :: &
          var_name = "plate_surface__thermal_diffusivity"
@@ -77,5 +84,30 @@ contains
 
     deallocate(val)
   end function test2
-  
+
+  ! Test getting model__identification_number.
+  function test3() result(code)
+    character (len=*), parameter :: &
+         var_name = "model__identification_number"
+    integer, parameter :: expected = 0
+    integer, pointer :: val(:)
+    integer :: i, code
+
+    status = m%initialize(config_file)
+    status = m%get_value(var_name, val)
+    status = m%finalize()
+
+    ! Visual inspection.
+    write(*,*) "Test 3"
+    write(*,*) val
+    write(*,*) expected
+
+    code = BMI_SUCCESS
+    if (val(1).ne.expected) then
+       code = BMI_FAILURE
+    end if
+
+    deallocate(val)
+  end function test3
+
 end program test_get_value

--- a/heat/tests/test_set_value.f90
+++ b/heat/tests/test_set_value.f90
@@ -20,6 +20,11 @@ program test_set_value
      stop BMI_FAILURE
   end if
 
+  retcode = test3()
+  if (retcode.ne.BMI_SUCCESS) then
+     stop BMI_FAILURE
+  end if
+
 contains
 
   function test1() result(code)
@@ -84,5 +89,36 @@ contains
     deallocate(x)
     deallocate(y)
   end function test2
+
+  function test3() result(code)
+    character (len=*), parameter :: &
+         var_name = "model__identification_number"
+    integer, parameter :: rank = 1
+    integer, parameter :: expected(rank) = (/ 42 /)
+    integer, pointer :: x(:), y(:)
+    integer :: i, code
+
+    status = m%initialize(config_file)
+    status = m%get_value(var_name, x)
+    status = m%set_value(var_name, expected)
+    status = m%get_value(var_name, y)
+    status = m%finalize()
+
+    ! Visual inspection.
+    write(*,*) "Test 3"
+    write(*,*) x
+    write(*,*) expected
+    write(*,*) y
+
+    code = BMI_SUCCESS
+    do i = 1, rank
+       if (y(i).ne.expected(i)) then
+          code = BMI_FAILURE
+       end if
+    end do
+
+    deallocate(x)
+    deallocate(y)
+  end function test3
 
 end program test_set_value


### PR DESCRIPTION
This PR addresses #14. Fortran needs the type and rank of array parameters at compile time. Rank isn't an issue here because arrays are flattened in BMI; however, we do need separate getters and setters for all Fortran intrinsic types. Here, I've implemented those for integers, floats, and doubles, following the guide of [SIDL types in Babel](https://computation.llnl.gov/projects/babel-high-performance-language-interoperability/docs/users_guide/index.html#htoc55). This places an additional burden on the model developer because they have to implement more BMI methods (even if they're just stubs). However, the user of the BMI doesn't need to worry about these typed getters and setters because they're implemented as [generic procedures](http://www.mrao.cam.ac.uk/~pa/f90Notes/HTMLNotesnode211.html) -- this means the user calls `get_value`, for example, and the compiler sorts out which typed method to call, based upon the the argument type.

cc @sc0tts, @mcflugen 