### PR TITLE
Output arrays, not pointers, from getters

### DIFF
--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -319,7 +319,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       integer, pointer, intent(inout) :: dest(:)
+       integer, intent(inout) :: dest(:)
        integer :: bmi_status
      end function bmif_get_value_int
 
@@ -328,7 +328,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       real, pointer, intent(inout) :: dest(:)
+       real, intent(inout) :: dest(:)
        integer :: bmi_status
      end function bmif_get_value_float
 
@@ -337,7 +337,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       double precision, pointer, intent(inout) :: dest(:)
+       double precision, intent(inout) :: dest(:)
        integer :: bmi_status
      end function bmif_get_value_double
 

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -377,7 +377,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       integer, pointer, intent(inout) :: dest(:)
+       integer, intent(inout) :: dest(:)
        integer, intent(in) :: indices(:)
        integer :: bmi_status
      end function bmif_get_value_at_indices_int
@@ -388,7 +388,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       real, pointer, intent(inout) :: dest(:)
+       real, intent(inout) :: dest(:)
        integer, intent(in) :: indices(:)
        integer :: bmi_status
      end function bmif_get_value_at_indices_float
@@ -399,7 +399,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
-       double precision, pointer, intent(inout) :: dest(:)
+       double precision, intent(inout) :: dest(:)
        integer, intent(in) :: indices(:)
        integer :: bmi_status
      end function bmif_get_value_at_indices_double

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -671,7 +671,7 @@ contains
        result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    integer, pointer, intent(inout) :: dest(:)
+    integer, intent(inout) :: dest(:)
     integer, intent(in) :: indices(:)
     integer :: bmi_status
     type (c_ptr) src
@@ -689,7 +689,7 @@ contains
        result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    real, pointer, intent(inout) :: dest(:)
+    real, intent(inout) :: dest(:)
     integer, intent(in) :: indices(:)
     integer :: bmi_status
     type (c_ptr) src
@@ -700,8 +700,7 @@ contains
     case("plate_surface__temperature")
        src = c_loc(self%model%temperature(1,1))
        call c_f_pointer(src, src_flattened, [self%model%n_y * self%model%n_x])
-       n_elements = size (indices)
-       allocate(dest(n_elements))
+       n_elements = size(indices)
        do i = 1, n_elements
           dest(i) = src_flattened(indices(i))
        end do
@@ -716,7 +715,7 @@ contains
        result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    double precision, pointer, intent(inout) :: dest(:)
+    double precision, intent(inout) :: dest(:)
     integer, intent(in) :: indices(:)
     integer :: bmi_status
     type (c_ptr) src

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -559,22 +559,15 @@ contains
   function heat_get_int(self, var_name, dest) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    integer, pointer, intent(inout) :: dest(:)
+    integer, intent(inout) :: dest(:)
     integer :: bmi_status
-    integer :: status, grid_id, grid_size
-
-    status = self%get_var_grid(var_name, grid_id)
-    status = self%get_grid_size(grid_id, grid_size)
 
     select case(var_name)
     case("model__identification_number")
-       allocate(dest(grid_size))
        dest = [self%model%id]
        bmi_status = BMI_SUCCESS
     case default
-       grid_size = 1
-       allocate(dest(grid_size))
-       dest = -1
+       dest = [-1]
        bmi_status = BMI_FAILURE
     end select
   end function heat_get_int
@@ -583,26 +576,28 @@ contains
   function heat_get_float(self, var_name, dest) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    real, pointer, intent(inout) :: dest(:)
+    real, intent(inout) :: dest(:)
     integer :: bmi_status
-    integer :: status, grid_id, grid_size
-
-    status = self%get_var_grid(var_name, grid_id)
-    status = self%get_grid_size(grid_id, grid_size)
 
     select case(var_name)
     case("plate_surface__temperature")
-       allocate(dest(grid_size))
-       dest = reshape(self%model%temperature, [grid_size])
+       ! This would be safe, but subject to indexing errors.
+       ! do j = 1, self%model%n_y
+       !    do i = 1, self%model%n_x
+       !       k = j + self%model%n_y*(i-1)
+       !       dest(k) = self%model%temperature(j,i)
+       !    end do
+       ! end do
+
+       ! This is an equivalent, elementwise copy into `dest`.
+       ! See https://stackoverflow.com/a/11800068/1563298
+       dest = reshape(self%model%temperature, [self%model%n_x*self%model%n_y])
        bmi_status = BMI_SUCCESS
     case("plate_surface__thermal_diffusivity")
-       allocate(dest(grid_size))
        dest = [self%model%alpha]
        bmi_status = BMI_SUCCESS
     case default
-       grid_size = 1
-       allocate(dest(grid_size))
-       dest = -1.0
+       dest = [-1.0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_get_float
@@ -611,18 +606,12 @@ contains
   function heat_get_double(self, var_name, dest) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     character (len=*), intent(in) :: var_name
-    double precision, pointer, intent(inout) :: dest(:)
+    double precision, intent(inout) :: dest(:)
     integer :: bmi_status
-    integer :: status, grid_id, grid_size
-
-    status = self%get_var_grid(var_name, grid_id)
-    status = self%get_grid_size(grid_id, grid_size)
 
     select case(var_name)
     case default
-       grid_size = 1
-       allocate(dest(grid_size))
-       dest = -1.d0
+       dest = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_get_double

--- a/heat/examples/change_diffusivity_ex.f90
+++ b/heat/examples/change_diffusivity_ex.f90
@@ -15,7 +15,7 @@ program change_diffusivity
   type (bmi_heat) :: m
   integer :: tgrid_id
   integer, dimension(2) :: tdims
-  real, pointer :: diffusivity(:), temperature(:)  
+  real :: diffusivity(1), temperature(50)  
   integer :: status
   
   ! Run model to the end with alpha=1.0 (from cfg file).
@@ -42,7 +42,4 @@ program change_diffusivity
   write(*,"(a)") "Run 2"
   write(*,"(a, f5.2)") "alpha =", diffusivity
   call print_array(temperature, tdims)
-
-  deallocate(diffusivity)
-  deallocate(temperature)
 end program change_diffusivity

--- a/heat/examples/conflicting_instances_ex.f90
+++ b/heat/examples/conflicting_instances_ex.f90
@@ -1,5 +1,5 @@
 ! Do two instances of bmi_heat conflict?
-program conflicting_instances_test
+program conflicting_instances_ex
 
   use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
@@ -13,8 +13,8 @@ program conflicting_instances_test
   integer :: s
   integer :: grid_id1, grid_id2
   character (len=BMI_MAX_VAR_NAME), pointer :: names1(:), names2(:)
-  integer :: dims1(2), dims2(2)
-  real, pointer :: z1(:), z2(:)
+  integer :: grid_size1, grid_size2, dims1(2), dims2(2)
+  real, allocatable :: z1(:), z2(:)
   character(len=30) :: rowfmt1, rowfmt2
 
   write(*, "(a, a10, a10)") "Configuration files: ", cfg_file1, cfg_file2
@@ -27,18 +27,22 @@ program conflicting_instances_test
   s = m1%get_output_var_names(names1)
   s = m1%get_var_grid(names1(1), grid_id1)
   s = m1%get_grid_shape(grid_id1, dims1)
+  s = m1%get_grid_size(grid_id1, grid_size1)
   write(rowfmt1,'(a,i4,a)') '(', dims1(2), '(1x,f6.1))'
 
   write (*, "(a)") "Initial values, model 1:"
+  allocate(z1(grid_size1))
   s = m1%get_value("plate_surface__temperature", z1)
   call print_array(z1, dims1)
 
   s = m2%get_output_var_names(names2)
   s = m2%get_var_grid(names2(1), grid_id2)
   s = m2%get_grid_shape(grid_id2, dims2)
+  s = m2%get_grid_size(grid_id2, grid_size2)
   write(rowfmt2,'(a,i4,a)') '(', dims2(2), '(1x,f6.1))'
 
   write (*, "(a)") "Initial values, model 2:"
+  allocate(z2(grid_size2))
   s = m2%get_value("plate_surface__temperature", z2)
   call print_array(z2, dims2)
 
@@ -62,8 +66,9 @@ program conflicting_instances_test
   call print_array(z2, dims2)
 
   write (*,"(a)", advance="no") "Finalizing..."
+  deallocate(z1, z2)
   s = m1%finalize()
   s = m2%finalize()
   write (*,*) "Done"
 
-end program conflicting_instances_test
+end program conflicting_instances_ex

--- a/heat/examples/get_value_ex.f90
+++ b/heat/examples/get_value_ex.f90
@@ -10,8 +10,8 @@ program get_value_ex
   integer :: s, i, j, grid_id
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
   integer :: grid_size, dims(2), locations(3)
-  real, allocatable :: z(:)
-  real, pointer :: y(:), x(:)
+  real, allocatable :: z(:), y(:)
+  real, pointer :: x(:)
   real :: time
 
   write (*,"(a)",advance="no") "Initializing..."
@@ -46,6 +46,7 @@ program get_value_ex
   write (*, "(a)") "Values at three locations:"
   locations = [21, 41, 62]
   write (*,*) "Locations: ", locations
+  allocate(y(size(locations)))
   s = m%get_value_at_indices("plate_surface__temperature", y, locations)
   write (*,*) "Values: ", y
 
@@ -66,7 +67,7 @@ program get_value_ex
   write (*,*) "Values: ", y
 
   write (*,"(a)", advance="no") "Finalizing..."
-  deallocate(z)
+  deallocate(z, y)
   s = m%finalize()
   write (*,*) "Done"
 

--- a/heat/examples/get_value_ex.f90
+++ b/heat/examples/get_value_ex.f90
@@ -1,5 +1,5 @@
 ! Test the get_value, get_value_ref, and get_value_at_indices functions.
-program get_value_test
+program get_value_ex
 
   use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
@@ -9,8 +9,9 @@ program get_value_test
   type (bmi_heat) :: m
   integer :: s, i, j, grid_id
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
-  integer :: dims(2), locations(3)
-  real, pointer :: z(:), y(:), x(:)
+  integer :: grid_size, dims(2), locations(3)
+  real, allocatable :: z(:)
+  real, pointer :: y(:), x(:)
   real :: time
 
   write (*,"(a)",advance="no") "Initializing..."
@@ -23,8 +24,11 @@ program get_value_test
   s = m%get_var_grid(names(1), grid_id)
   s = m%get_grid_shape(grid_id, dims)
   write(*,'(a,2i4)') 'Grid shape (ny,nx): ', dims
+  s = m%get_grid_size(grid_id, grid_size)
+  write(*,'(a,i8)') 'Grid size: ', grid_size
 
   write (*, "(a)") "Initial values:"
+  allocate(z(grid_size))
   s = m%get_value("plate_surface__temperature", z)
   call print_array(z, dims)
   write (*, "(a, i5)") "Shape of returned values:", shape(z)
@@ -62,7 +66,8 @@ program get_value_test
   write (*,*) "Values: ", y
 
   write (*,"(a)", advance="no") "Finalizing..."
+  deallocate(z)
   s = m%finalize()
   write (*,*) "Done"
 
-end program get_value_test
+end program get_value_ex

--- a/heat/examples/set_value_ex.f90
+++ b/heat/examples/set_value_ex.f90
@@ -1,5 +1,5 @@
 ! Test the set_value and set_value_at_indices functions.
-program set_value_test
+program set_value_ex
 
   use bmif, only: BMI_MAX_VAR_NAME
   use bmiheatf
@@ -9,9 +9,9 @@ program set_value_test
   type (bmi_heat) :: m
   integer :: s, i, j, grid_id
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
-  integer :: dims(2), locations(3)
+  integer :: grid_size, dims(2), locations(3)
   real :: values(3)
-  real, pointer :: z(:), y(:)
+  real, allocatable :: z(:), y(:)
   character(len=30) :: rowfmt
 
   write (*,"(a)",advance="no") "Initializing..."
@@ -24,8 +24,11 @@ program set_value_test
   s = m%get_var_grid(names(1), grid_id)
   s = m%get_grid_shape(grid_id, dims)
   write(rowfmt,'(a,i4,a)') '(', dims(2), '(1x,f6.1))'
+  s = m%get_grid_size(grid_id, grid_size)
+  write(*,'(a,i8)') 'Grid size: ', grid_size
 
   write (*, "(a)") "Initial values:"
+  allocate(z(grid_size))
   s = m%get_value("plate_surface__temperature", z)
   call print_array(z, dims)
 
@@ -34,6 +37,7 @@ program set_value_test
   s = m%set_value("plate_surface__temperature", z)
   write (*,*) "Done."
   write (*, "(a)") "New values:"
+  allocate(y(grid_size))
   s = m%get_value("plate_surface__temperature", y)
   call print_array(y, dims)
 
@@ -48,7 +52,8 @@ program set_value_test
   call print_array(y, dims)
 
   write (*,"(a)", advance="no") "Finalizing..."
+  deallocate(z, y)
   s = m%finalize()
   write (*,*) "Done"
 
-end program set_value_test
+end program set_value_ex

--- a/heat/tests/test_by_reference.f90
+++ b/heat/tests/test_by_reference.f90
@@ -22,11 +22,17 @@ contains
   function run_test() result(code)
     type (bmi_heat) :: m
     integer, dimension(rank) :: shape
-    real, pointer :: tval(:), tref(:)
+    integer :: size
+    real, allocatable :: tval(:)
+    real, pointer :: tref(:)
     integer :: code
 
     status = m%initialize(config_file)
     status = m%get_grid_shape(grid_id, shape)
+    status = m%get_grid_size(grid_id, size)
+
+    ! Dynamically allocate memory for the temperature values.
+    allocate(tval(size))
 
     ! Get initial temperature array, by value and by reference.
     status = m%get_value("plate_surface__temperature", tval)

--- a/heat/tests/test_get_value.f90
+++ b/heat/tests/test_get_value.f90
@@ -32,10 +32,11 @@ contains
     character (len=*), parameter :: &
          var_name = "plate_surface__temperature"
     integer, parameter :: rank = 2
+    integer, parameter :: size = 50
     integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
     real, parameter, dimension(shape(2)) :: &
          expected = (/ 0.0, 3.0, 4.0, 3.0, 0.0 /)
-    real, pointer :: tval(:)
+    real :: tval(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -56,16 +57,15 @@ contains
           exit
        end if
     end do
-
-    deallocate(tval)
   end function test1
 
   ! Test getting plate_surface__thermal_diffusivity.
   function test2() result(code)
     character (len=*), parameter :: &
          var_name = "plate_surface__thermal_diffusivity"
-    real, parameter :: expected = 1.0
-    real, pointer :: val(:)
+    integer, parameter :: size = 1
+    real, parameter :: expected(size) = (/ 1.0 /)
+    real :: val(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -78,19 +78,20 @@ contains
     write(*,*) expected
 
     code = BMI_SUCCESS
-    if (val(1).ne.expected) then
-       code = BMI_FAILURE
-    end if
-
-    deallocate(val)
+    do i = 1, size
+       if (val(i).ne.expected(i)) then
+          code = BMI_FAILURE
+       end if
+    end do
   end function test2
 
   ! Test getting model__identification_number.
   function test3() result(code)
     character (len=*), parameter :: &
          var_name = "model__identification_number"
-    integer, parameter :: expected = 0
-    integer, pointer :: val(:)
+    integer, parameter :: size = 1
+    integer, parameter :: expected(size) = (/ 0 /)
+    integer :: val(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -103,11 +104,11 @@ contains
     write(*,*) expected
 
     code = BMI_SUCCESS
-    if (val(1).ne.expected) then
-       code = BMI_FAILURE
-    end if
-
-    deallocate(val)
+    do i = 1, size
+       if (val(i).ne.expected(i)) then
+          code = BMI_FAILURE
+       end if
+    end do
   end function test3
 
 end program test_get_value

--- a/heat/tests/test_get_value_at_indices.f90
+++ b/heat/tests/test_get_value_at_indices.f90
@@ -25,9 +25,11 @@ contains
 
   function run_test() result(code)
     type (bmi_heat) :: m
-    real, pointer :: tval(:)
+    real, allocatable :: tval(:)
     integer :: i
     integer :: code
+
+    allocate(tval(size(indices)))
 
     status = m%initialize(config_file)
     status = m%get_value_at_indices(var_name, tval, indices)

--- a/heat/tests/test_set_value.f90
+++ b/heat/tests/test_set_value.f90
@@ -31,8 +31,9 @@ contains
     character (len=*), parameter :: &
          var_name = "plate_surface__temperature"
     integer, parameter :: rank = 2
+    integer, parameter :: size = 50
     integer, parameter :: shape(rank) = (/ 10, 5 /)
-    real, pointer :: x(:), y(:)
+    real :: x(size), y(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -54,17 +55,14 @@ contains
           exit
        end if
     end do
-
-    deallocate(x)
-    deallocate(y)
   end function test1
 
   function test2() result(code)
     character (len=*), parameter :: &
          var_name = "plate_surface__thermal_diffusivity"
-    integer, parameter :: rank = 1
-    real, parameter :: expected(rank) = (/ 0.75 /)
-    real, pointer :: x(:), y(:)
+    integer, parameter :: size = 1
+    real, parameter :: expected(size) = (/ 0.75 /)
+    real :: x(size), y(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -80,22 +78,19 @@ contains
     write(*,*) y
 
     code = BMI_SUCCESS
-    do i = 1, rank
+    do i = 1, size
        if (y(i).ne.expected(i)) then
           code = BMI_FAILURE
        end if
     end do
-
-    deallocate(x)
-    deallocate(y)
   end function test2
 
   function test3() result(code)
     character (len=*), parameter :: &
          var_name = "model__identification_number"
-    integer, parameter :: rank = 1
-    integer, parameter :: expected(rank) = (/ 42 /)
-    integer, pointer :: x(:), y(:)
+    integer, parameter :: size = 1
+    integer, parameter :: expected(size) = (/ 42 /)
+    integer :: x(size), y(size)
     integer :: i, code
 
     status = m%initialize(config_file)
@@ -111,14 +106,11 @@ contains
     write(*,*) y
 
     code = BMI_SUCCESS
-    do i = 1, rank
+    do i = 1, size
        if (y(i).ne.expected(i)) then
           code = BMI_FAILURE
        end if
     end do
-
-    deallocate(x)
-    deallocate(y)
   end function test3
 
 end program test_set_value

--- a/heat/tests/test_set_value_at_indices.f90
+++ b/heat/tests/test_set_value_at_indices.f90
@@ -9,6 +9,7 @@ program test_set_value_at_indices
   character (len=*), parameter :: config_file = "sample.cfg"
   character (len=*), parameter :: var_name = "plate_surface__temperature"
   integer, parameter :: rank = 2
+  integer, parameter :: size = 50
   integer, parameter, dimension(rank) :: shape = (/ 10, 5 /)
   integer, parameter, dimension(shape(2)) :: &
        indices = (/ 2, 12, 22, 32, 42 /)
@@ -25,9 +26,8 @@ contains
 
   function run_test() result(code)
     type (bmi_heat) :: m
-    real, pointer :: x(:)
-    integer :: i
-    integer :: code
+    real :: x(size)
+    integer :: i, code
 
     status = m%initialize(config_file)
     status = m%set_value_at_indices(var_name, indices, expected)
@@ -46,8 +46,6 @@ contains
           exit
        end if
     end do
-
-    deallocate(x)
   end function run_test
 
 end program test_set_value_at_indices


### PR DESCRIPTION
A BMI should not allocate memory. Instead, when using, e.g., `get_value`, the caller should create a variable, allocating memory to hold an array output. The variable is passed as a parameter into
`get_value`, where values are copied into it.

Fortran arrays actually make this easy. For example, in `get_grid_shape`, these statements

    shape(1) = self%model%n_y
    shape(2) = self%model%n_x

and this statement

    shape = [self%model%n_y, self%model%n_x]

are equivalent, element-wise copies into the variable `shape`.

In this PR, I've used this concept to rework the the `get_value` and `get_value_at_indices` methods, outputting an array, not a pointer, with the values of the specified variable.

(Thank you to @mcflugen for recognizing this problem on his way out the door yesterday.)

cc: @sc0tts