### PR TITLE
Update time methods

### DIFF
--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -109,7 +109,7 @@ module bmif
      function bmif_get_start_time(self, time) result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
-       real, intent(out) :: time
+       double precision, intent(out) :: time
        integer :: bmi_status
      end function bmif_get_start_time
 
@@ -117,7 +117,7 @@ module bmif
      function bmif_get_end_time(self, time) result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
-       real, intent(out) :: time
+       double precision, intent(out) :: time
        integer :: bmi_status
      end function bmif_get_end_time
 
@@ -125,7 +125,7 @@ module bmif
      function bmif_get_current_time(self, time) result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
-       real, intent(out) :: time
+       double precision, intent(out) :: time
        integer :: bmi_status
      end function bmif_get_current_time
 
@@ -133,7 +133,7 @@ module bmif
      function bmif_get_time_step(self, time_step) result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
-       real, intent(out) :: time_step
+       double precision, intent(out) :: time_step
        integer :: bmi_status
      end function bmif_get_time_step
 
@@ -156,7 +156,7 @@ module bmif
      function bmif_update_frac(self, time_frac) result(bmi_status)
        import :: bmi
        class (bmi), intent(inout) :: self
-       real, intent(in) :: time_frac
+       double precision, intent(in) :: time_frac
        integer :: bmi_status
      end function bmif_update_frac
 
@@ -164,7 +164,7 @@ module bmif
      function bmif_update_until(self, time) result(bmi_status)
        import :: bmi
        class (bmi), intent(inout) :: self
-       real, intent(in) :: time
+       double precision, intent(in) :: time
        integer :: bmi_status
      end function bmif_update_until
 

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -153,40 +153,40 @@ contains
   ! Model start time.
   function heat_start_time(self, time) result (bmi_status)
     class (bmi_heat), intent(in) :: self
-    real, intent(out) :: time
+    double precision, intent(out) :: time
     integer :: bmi_status
 
-    time = 0.0
+    time = 0.d0
     bmi_status = BMI_SUCCESS
   end function heat_start_time
 
   ! Model end time.
   function heat_end_time(self, time) result (bmi_status)
     class (bmi_heat), intent(in) :: self
-    real, intent(out) :: time
+    double precision, intent(out) :: time
     integer :: bmi_status
 
-    time = self%model%t_end
+    time = dble(self%model%t_end)
     bmi_status = BMI_SUCCESS
   end function heat_end_time
 
   ! Model current time.
   function heat_current_time(self, time) result (bmi_status)
     class (bmi_heat), intent(in) :: self
-    real, intent(out) :: time
+    double precision, intent(out) :: time
     integer :: bmi_status
 
-    time = self%model%t
+    time = dble(self%model%t)
     bmi_status = BMI_SUCCESS
   end function heat_current_time
 
   ! Model time step.
   function heat_time_step(self, time_step) result (bmi_status)
     class (bmi_heat), intent(in) :: self
-    real, intent(out) :: time_step
+    double precision, intent(out) :: time_step
     integer :: bmi_status
 
-    time_step = self%model%dt
+    time_step = dble(self%model%dt)
     bmi_status = BMI_SUCCESS
   end function heat_time_step
 
@@ -212,13 +212,13 @@ contains
   ! Advance the model by a fraction of a time step.
   function heat_update_frac(self, time_frac) result (bmi_status)
     class (bmi_heat), intent(inout) :: self
-    real, intent(in) :: time_frac
+    double precision, intent(in) :: time_frac
     integer :: bmi_status
     real :: time_step
 
     if (time_frac > 0.0) then
        time_step = self%model%dt
-       self%model%dt = time_step*time_frac
+       self%model%dt = time_step*real(time_frac)
        call advance_in_time(self%model)
        self%model%dt = time_step
     end if
@@ -228,9 +228,9 @@ contains
   ! Advance the model until the given time.
   function heat_update_until(self, time) result (bmi_status)
     class (bmi_heat), intent(inout) :: self
-    real, intent(in) :: time
+    double precision, intent(in) :: time
     integer :: bmi_status
-    real :: n_steps_real
+    double precision :: n_steps_real
     integer :: n_steps, i, s
 
     if (time > self%model%t) then
@@ -239,7 +239,7 @@ contains
        do i = 1, n_steps
           s = self%update()
        end do
-       s = self%update_frac(n_steps_real - real(n_steps))
+       s = self%update_frac(n_steps_real - dble(n_steps))
     end if
     bmi_status = BMI_SUCCESS
   end function heat_update_until

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -196,7 +196,7 @@ contains
     character (len=*), intent(out) :: time_units
     integer :: bmi_status
 
-    time_units = "-"
+    time_units = "s"
     bmi_status = BMI_SUCCESS
   end function heat_time_units
 

--- a/heat/examples/change_diffusivity_ex.f90
+++ b/heat/examples/change_diffusivity_ex.f90
@@ -10,7 +10,7 @@ program change_diffusivity
        dname = "plate_surface__thermal_diffusivity"
   character (len=*), parameter :: &
        tname = "plate_surface__temperature"
-  real, parameter :: end_time = 20.0
+  double precision, parameter :: end_time = 20.d0
 
   type (bmi_heat) :: m
   integer :: tgrid_id

--- a/heat/examples/get_value_ex.f90
+++ b/heat/examples/get_value_ex.f90
@@ -12,7 +12,7 @@ program get_value_ex
   integer :: grid_size, dims(2), locations(3)
   real, allocatable :: z(:), y(:)
   real, pointer :: x(:)
-  real :: time
+  double precision :: time
 
   write (*,"(a)",advance="no") "Initializing..."
   s = m%initialize("")

--- a/heat/examples/irf_ex.f90
+++ b/heat/examples/irf_ex.f90
@@ -7,7 +7,7 @@ program irf_test
 
   type (bmi_heat) :: m
   integer :: s, i
-  real :: time, time0, time1
+  double precision :: time, time0, time1
   character (len=BMI_MAX_UNITS_NAME) :: time_units
 
   write (*,"(a)",advance="no") "Initializing..."
@@ -42,7 +42,7 @@ program irf_test
   write (*,"(a)") "Update a fraction of a time step"
   s = m%get_current_time(time0)
   write (*,"(a30, f8.2)") "Start time: ", time0
-  s = m%update_frac(0.5)
+  s = m%update_frac(0.d5)
   s = m%get_current_time(time1)
   write (*,"(a30, f8.2)") "Stop time: ", time1
 

--- a/heat/tests/test_get_current_time.f90
+++ b/heat/tests/test_get_current_time.f90
@@ -6,10 +6,10 @@ program test_get_current_time
 
   implicit none
 
-  integer, parameter :: expected_time = 0.0
+  double precision, parameter :: expected_time = 0.d0
 
   type (bmi_heat) :: m
-  real :: current_time
+  double precision :: current_time
 
   status = m%initialize(config_file)
   status = m%get_current_time(current_time)

--- a/heat/tests/test_get_end_time.f90
+++ b/heat/tests/test_get_end_time.f90
@@ -6,10 +6,10 @@ program test_get_end_time
 
   implicit none
 
-  integer, parameter :: expected_time = 20.0
+  double precision, parameter :: expected_time = 20.d0
 
   type (bmi_heat) :: m
-  real :: end_time
+  double precision :: end_time
 
   status = m%initialize(config_file)
   status = m%get_end_time(end_time)

--- a/heat/tests/test_get_start_time.f90
+++ b/heat/tests/test_get_start_time.f90
@@ -6,10 +6,10 @@ program test_get_start_time
 
   implicit none
 
-  integer, parameter :: expected_time = 0.0
+  double precision, parameter :: expected_time = 0.d0
 
   type (bmi_heat) :: m
-  real :: start_time
+  double precision :: start_time
 
   status = m%initialize(config_file)
   status = m%get_start_time(start_time)

--- a/heat/tests/test_get_time_step.f90
+++ b/heat/tests/test_get_time_step.f90
@@ -6,10 +6,10 @@ program test_get_time_step
 
   implicit none
 
-  integer, parameter :: expected_time_step = 1.0
+  double precision, parameter :: expected_time_step = 1.d0
 
   type (bmi_heat) :: m
-  real :: time_step
+  double precision :: time_step
 
   status = m%initialize(config_file)
   status = m%get_time_step(time_step)

--- a/heat/tests/test_get_time_units.f90
+++ b/heat/tests/test_get_time_units.f90
@@ -6,7 +6,7 @@ program test_get_time_units
 
   implicit none
 
-  character (len=*), parameter :: expected_units = "-"
+  character (len=*), parameter :: expected_units = "s"
 
   type (bmi_heat) :: m
   character (len=BMI_MAX_UNITS_NAME) :: units

--- a/heat/tests/test_update.f90
+++ b/heat/tests/test_update.f90
@@ -6,10 +6,10 @@ program test_update
 
   implicit none
 
-  integer, parameter :: expected_time = 1.0
+  double precision, parameter :: expected_time = 1.d0
 
   type (bmi_heat) :: m
-  real :: time
+  double precision :: time
 
   status = m%initialize(config_file)
   status = m%update()

--- a/heat/tests/test_update_frac.f90
+++ b/heat/tests/test_update_frac.f90
@@ -6,10 +6,10 @@ program test_update_frac
 
   implicit none
 
-  real, parameter :: expected_time = 0.5
+  double precision, parameter :: expected_time = 0.d5
 
   type (bmi_heat) :: m
-  real :: time
+  double precision :: time
 
   status = m%initialize(config_file)
   status = m%update_frac(expected_time)

--- a/heat/tests/test_update_until.f90
+++ b/heat/tests/test_update_until.f90
@@ -6,10 +6,10 @@ program test_update_until
 
   implicit none
 
-  real, parameter :: expected_time = 10.0
+  double precision, parameter :: expected_time = 10.d0
 
   type (bmi_heat) :: m
-  real :: time
+  double precision :: time
 
   status = m%initialize(config_file)
   status = m%update_until(expected_time)


### PR DESCRIPTION
The time methods (e.g., `get_start_time`, `get_end_time`, etc.) plus the update methods, should use double precision values for time, as defined in the [BMI specification](https://bmi-spec.readthedocs.io/en/latest/bmi.time_funcs.html). I've updated these methods to follow the spec. This fixes #20.

Also, in a minor change, I've made the time units seconds in the sample implementation.

All the tests and examples are updated to match these changes.
