### PR TITLE
Add conda-build recipe

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+mkdir _build && cd _build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX
+make
+make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "bmi-fortran" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/csdms/bmi-fortran
+  git_rev: v{{ version }}-beta
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('fortran') }}
+    - pkg-config [osx]
+  host:
+    - libgfortran
+  run:
+    - libgfortran
+
+test:
+  commands:
+    - run_heatf
+
+about:
+  home: https://csdms.colorado.edu/wiki/BMI_Description
+  license: MIT
+  summary:
+    Fortran bindings, created with Fortran 2003, for the Basic Model Interface.
+  dev_url: https://github.com/csdms/bmi-fortran


### PR DESCRIPTION
This PR adds a `conda-build` recipe.

Note that I added the "beta" tag. Remove this when v1.0 is tagged.