### PR TITLE
Fix conda build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,3 +4,13 @@ mkdir _build && cd _build
 cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX
 make
 make install
+
+# Why are Fortran .mod files being compressed?
+if [[ `uname -s` == 'Linux' ]]; then
+    cd $PREFIX/lib
+    mod_files=`ls -1 *.mod`
+    for f in $mod_files; do
+	mv $f $f.gz
+	gunzip $f.gz
+    done
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v{{ version }}-beta
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -20,6 +20,7 @@ requirements:
   host:
     - libgfortran
   run:
+    - {{ compiler('fortran') }}
     - libgfortran
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v{{ version }}-beta
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
For reasons I haven't determined, the Fortran **.mod** files created during the build process were distributed on Linux as gzip compressed files. I manually `gunzip`ped them before packaging.

I also included the conda Fortran compiler as a run requirement. This ensures that a Fortran compiler is present and compatible with the libraries that are built.
