### PR TITLE
Update grid output types

### DIFF
--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -227,7 +227,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_origin
+       double precision, dimension(:), intent(out) :: grid_origin
        integer :: bmi_status
      end function bmif_get_grid_origin
 

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -236,7 +236,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_x
+       double precision, dimension(:), intent(out) :: grid_x
        integer :: bmi_status
      end function bmif_get_grid_x
 
@@ -245,7 +245,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_y
+       double precision, dimension(:), intent(out) :: grid_y
        integer :: bmi_status
      end function bmif_get_grid_y
 
@@ -254,7 +254,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_z
+       double precision, dimension(:), intent(out) :: grid_z
        integer :: bmi_status
      end function bmif_get_grid_z
 

--- a/bmi/bmi.f90
+++ b/bmi/bmi.f90
@@ -218,7 +218,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_spacing
+       double precision, dimension(:), intent(out) :: grid_spacing
        integer :: bmi_status
      end function bmif_get_grid_spacing
 

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -382,15 +382,15 @@ contains
   function heat_grid_x(self, grid_id, grid_x) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     integer, intent(in) :: grid_id
-    real, dimension(:), intent(out) :: grid_x
+    double precision, dimension(:), intent(out) :: grid_x
     integer :: bmi_status
 
     select case(grid_id)
     case(1)
-       grid_x = [0.0]
+       grid_x = [0.d0]
        bmi_status = BMI_SUCCESS
     case default
-       grid_x = [-1.0]
+       grid_x = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_x
@@ -399,15 +399,15 @@ contains
   function heat_grid_y(self, grid_id, grid_y) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     integer, intent(in) :: grid_id
-    real, dimension(:), intent(out) :: grid_y
+    double precision, dimension(:), intent(out) :: grid_y
     integer :: bmi_status
 
     select case(grid_id)
     case(1)
-       grid_y = [0.0]
+       grid_y = [0.d0]
        bmi_status = BMI_SUCCESS
     case default
-       grid_y = [-1.0]
+       grid_y = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_y
@@ -416,15 +416,15 @@ contains
   function heat_grid_z(self, grid_id, grid_z) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     integer, intent(in) :: grid_id
-    real, dimension(:), intent(out) :: grid_z
+    double precision, dimension(:), intent(out) :: grid_z
     integer :: bmi_status
 
     select case(grid_id)
     case(1)
-       grid_z = [0.0]
+       grid_z = [0.d0]
        bmi_status = BMI_SUCCESS
     case default
-       grid_z = [-1.0]
+       grid_z = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_z

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -365,15 +365,15 @@ contains
   function heat_grid_origin(self, grid_id, grid_origin) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     integer, intent(in) :: grid_id
-    real, dimension(:), intent(out) :: grid_origin
+    double precision, dimension(:), intent(out) :: grid_origin
     integer :: bmi_status
 
     select case(grid_id)
     case(0)
-       grid_origin = [0.0, 0.0]
+       grid_origin = [0.d0, 0.d0]
        bmi_status = BMI_SUCCESS
     case default
-       grid_origin = [-1.0]
+       grid_origin = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_origin

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -356,7 +356,7 @@ contains
        grid_spacing = [self%model%dy, self%model%dx]
        bmi_status = BMI_SUCCESS
     case default
-       grid_spacing = -1.d0
+       grid_spacing = [-1.d0]
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_spacing

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -348,7 +348,7 @@ contains
   function heat_grid_spacing(self, grid_id, grid_spacing) result (bmi_status)
     class (bmi_heat), intent(in) :: self
     integer, intent(in) :: grid_id
-    real, dimension(:), intent(out) :: grid_spacing
+    double precision, dimension(:), intent(out) :: grid_spacing
     integer :: bmi_status
 
     select case(grid_id)
@@ -356,7 +356,7 @@ contains
        grid_spacing = [self%model%dy, self%model%dx]
        bmi_status = BMI_SUCCESS
     case default
-       grid_spacing = -1
+       grid_spacing = -1.d0
        bmi_status = BMI_FAILURE
     end select
   end function heat_grid_spacing

--- a/heat/examples/vargrid_ex.f90
+++ b/heat/examples/vargrid_ex.f90
@@ -11,7 +11,6 @@ program vargrid_test
   integer :: grid_id
   character (len=BMI_MAX_VAR_NAME) :: astring
   integer :: asize
-  real, dimension(2) :: rarray
   double precision, dimension(2) :: darray
   integer, dimension(2) :: iarray
 
@@ -30,8 +29,8 @@ program vargrid_test
 
   s = m%get_grid_type(grid_id, astring)
   write (*,"(a30, 1x, a30)") "Grid type:", astring
-  s = m%get_grid_origin(grid_id, rarray)
-  write (*,"(a30, 1x, 2(f8.2))") "Grid origin:", rarray
+  s = m%get_grid_origin(grid_id, darray)
+  write (*,"(a30, 1x, 2(f8.2))") "Grid origin:", darray
   s = m%get_grid_rank(grid_id, asize)
   write (*,"(a30, i3)") "Grid rank:", asize
   s = m%get_grid_shape(grid_id, iarray)

--- a/heat/examples/vargrid_ex.f90
+++ b/heat/examples/vargrid_ex.f90
@@ -12,6 +12,7 @@ program vargrid_test
   character (len=BMI_MAX_VAR_NAME) :: astring
   integer :: asize
   real, dimension(2) :: rarray
+  double precision, dimension(2) :: darray
   integer, dimension(2) :: iarray
 
   write (*,"(a)",advance="no") "Initializing..."
@@ -37,8 +38,8 @@ program vargrid_test
   write (*,"(a30, 2(1x, i3))") "Grid shape:", iarray
   s = m%get_grid_size(grid_id, asize)
   write (*,"(a30, i8)") "Grid size:", asize
-  s = m%get_grid_spacing(grid_id, rarray)
-  write (*,"(a30, 1x, 2(f8.2))") "Grid spacing:", rarray
+  s = m%get_grid_spacing(grid_id, darray)
+  write (*,"(a30, 1x, 2(f8.2))") "Grid spacing:", darray
 
   s = m%get_var_itemsize(names(1), asize)
   write (*,"(a30, i8, 1x, a)") "Item size:", asize, "bytes"

--- a/heat/tests/test_get_grid_origin.f90
+++ b/heat/tests/test_get_grid_origin.f90
@@ -8,10 +8,11 @@ program test_get_grid_origin
 
   integer, parameter :: grid_id = 0
   integer, parameter :: rank = 2
-  real, dimension(rank), parameter :: expected_origin = [0.0, 0.0]
+  double precision, dimension(rank), parameter :: &
+       expected_origin = [0.0, 0.0]
 
   type (bmi_heat) :: m
-  real, dimension(2) :: grid_origin
+  double precision, dimension(2) :: grid_origin
   integer :: i
 
   status = m%initialize(config_file)

--- a/heat/tests/test_get_grid_spacing.f90
+++ b/heat/tests/test_get_grid_spacing.f90
@@ -8,10 +8,11 @@ program test_get_grid_spacing
 
   integer, parameter :: grid_id = 0
   integer, parameter :: rank = 2
-  real, dimension(rank), parameter :: expected_spacing = [1.0, 1.0]
+  double precision, dimension(rank), parameter :: &
+       expected_spacing = [1.0, 1.0]
 
   type (bmi_heat) :: m
-  real, dimension(2) :: grid_spacing
+  double precision, dimension(2) :: grid_spacing
   integer :: i
 
   status = m%initialize(config_file)

--- a/heat/tests/test_get_grid_x.f90
+++ b/heat/tests/test_get_grid_x.f90
@@ -8,10 +8,10 @@ program test_get_grid_x
 
   integer, parameter :: grid_id = 1
   integer, parameter :: nx = 1
-  real, parameter, dimension(nx) :: expected_x = (/ 0.0 /)
+  double precision, parameter, dimension(nx) :: expected_x = (/ 0.0 /)
 
   type (bmi_heat) :: m
-  real, dimension(nx) :: grid_x
+  double precision, dimension(nx) :: grid_x
   integer :: i
 
   status = m%initialize(config_file)

--- a/heat/tests/test_get_grid_y.f90
+++ b/heat/tests/test_get_grid_y.f90
@@ -8,10 +8,10 @@ program test_get_grid_y
 
   integer, parameter :: grid_id = 1
   integer, parameter :: ny = 1
-  real, parameter, dimension(ny) :: expected_y = (/ 0.0 /)
+  double precision, parameter, dimension(ny) :: expected_y = (/ 0.0 /)
 
   type (bmi_heat) :: m
-  real, dimension(ny) :: grid_y
+  double precision, dimension(ny) :: grid_y
   integer :: i
 
   status = m%initialize(config_file)

--- a/heat/tests/test_get_grid_z.f90
+++ b/heat/tests/test_get_grid_z.f90
@@ -8,10 +8,10 @@ program test_get_grid_z
 
   integer, parameter :: grid_id = 1
   integer, parameter :: nz = 1
-  real, parameter, dimension(nz) :: expected_z = (/ 0.0 /)
+  double precision, parameter, dimension(nz) :: expected_z = (/ 0.0 /)
 
   type (bmi_heat) :: m
-  real, dimension(nz) :: grid_z
+  double precision, dimension(nz) :: grid_z
   integer :: i
 
   status = m%initialize(config_file)


### PR DESCRIPTION
To correctly match the [BMI specification](https://bmi-spec.readthedocs.io/en/latest/bmi.grid_funcs.html), I've updated the output types for

* `get_grid_spacing`
* `get_grid_origin`
* `get_grid_x`
* `get_grid_y`
* `get_grid_z`

to `double precision` (which is a C/Python float) from `real`.