### PR TITLE
Add BMI main example

### DIFF
--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -1,19 +1,26 @@
 set(pkg_name heatf)
 set(mod_name ${pkg_name})
-set(src_${pkg_name} heat.f90 bmi_heat.f90 main.f90)
+set(src_${pkg_name} heat.f90 main.f90)
+set(src_bmi${pkg_name} heat.f90 bmi_heat.f90 bmi_main.f90)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${pkg_name}.pc.cmake
   ${CMAKE_CURRENT_SOURCE_DIR}/${pkg_name}.pc)
 
-add_library(${bmiheat_lib} SHARED ${src_${pkg_name}})
+add_library(${bmiheat_lib} SHARED ${src_bmi${pkg_name}})
 target_link_libraries(${bmiheat_lib} ${bmi_lib})
 
 add_executable(run_${pkg_name} ${src_${pkg_name}})
-target_link_libraries(run_${pkg_name} ${bmi_lib})
+
+add_executable(run_bmi${pkg_name} ${src_bmi${pkg_name}})
+target_link_libraries(run_bmi${pkg_name} ${bmi_lib} ${bmiheat_lib})
 
 install(
   PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_${pkg_name}
+  DESTINATION bin
+  COMPONENT ${pkg_name})
+install(
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_bmi${pkg_name}
   DESTINATION bin
   COMPONENT ${pkg_name})
 install(

--- a/heat/README.md
+++ b/heat/README.md
@@ -11,7 +11,8 @@ Tests and examples of using the BMI are provided.
 Files and directories:
 
 * **heat.f90**: The diffusion model, `heatf`.
-* **main.f90**: A main program that runs `heatf`.
+* **main.f90**: An example main program that runs `heatf`.
 * **bmi_heat.f90**: A BMI that wraps `heatf`.
+* **bmi_main.f90**: An example main program that runs `heatf` through its BMI.
 * **examples/**: Examples of running the `heatf` BMI.
 * **tests/**: Unit tests for the `heatf` BMI.

--- a/heat/bmi_main.f90
+++ b/heat/bmi_main.f90
@@ -1,0 +1,43 @@
+! Run the heat model through its BMI.
+program bmi_main
+
+  use bmiheatf
+  implicit none
+
+  character (len=*), parameter :: var_name = "plate_surface__temperature"
+  integer, parameter :: ndims = 2
+
+  type (bmi_heat) :: model
+  integer :: i, j, s, grid_id, grid_size, grid_shape(ndims)
+  double precision :: current_time, end_time
+  real, allocatable :: temperature(:)
+
+  write(*,"(a)") "Initialize"
+  s = model%initialize("")
+
+  s = model%get_current_time(current_time)
+  s = model%get_end_time(end_time)
+  s = model%get_var_grid(var_name, grid_id)
+  s = model%get_grid_size(grid_id, grid_size)
+  s = model%get_grid_shape(grid_id, grid_shape)
+
+  allocate(temperature(grid_size))
+
+  do while (current_time <= end_time)
+     write(*,"(a, f6.1)") "Model values at time = ", current_time
+     s = model%get_value(var_name, temperature)
+     do j = 1, grid_shape(1)
+        do i = 1, grid_shape(2)
+           write (*,"(f6.1)", advance="no") temperature(j + grid_shape(1)*(i-1))
+        end do
+        write (*,*)
+     end do
+     s = model%update()
+     s = model%get_current_time(current_time)
+  end do
+
+  deallocate(temperature)
+  s = model%finalize()
+  write(*,"(a)") "Finalize"
+
+end program bmi_main

--- a/heat/main.f90
+++ b/heat/main.f90
@@ -1,4 +1,4 @@
-! Run the heat model using its BMI.
+! Run the heat model.
 program main
 
   use heatf


### PR DESCRIPTION
The sample implementation includes a main program that demonstrates how to run the *heatf* model, but it doesn't have an equivalent that runs the model through its BMI. This PR adds such a program.