### PR TITLE
Build and deploy conda recipe with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - ctest
 after_success:
   - cd ..
-  - conda build ./recipe --old-build-string
+  - conda build ./recipe
 after_script:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
-  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms --old-build-string --token=-
+  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms --token=-

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ before_install:
   - conda install python=$TRAVIS_PYTHON_VERSION
   - conda install -q conda-build anaconda-client
   - conda install gfortran_$TRAVIS_OS_NAME-64 libgfortran cmake
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export FC=$CONDA_PREFIX/bin/x86_64-conda_cos6-linux-gnu-gfortran
+    fi
 install:
   - mkdir _build && cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ os:
   - osx
 env:
   global:
+    - TRAVIS_PYTHON_VERSION="3.6"
     - CONDA_PREFIX=$HOME/conda
-    - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
-    - TRAVIS_PYTHON_VERSION="2.7"
+    - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
 sudo: false
 before_install:
   - |
@@ -21,16 +21,11 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda install gcc libgfortran cmake
-    else
-      conda install gfortran_linux-64 cmake
-      export FC=$CONDA_PREFIX/bin/x86_64-conda_cos6-linux-gnu-gfortran
-    fi
+  - conda install -q conda-build anaconda-client
+  - conda install gfortran_$TRAVIS_OS_NAME-64 libgfortran cmake
 install:
   - mkdir _build && cd _build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install -DCMAKE_VERBOSE_MAKEFILE=True
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install
   - make install
 before_script:
   - |
@@ -39,3 +34,6 @@ before_script:
     fi
 script:
   - ctest
+after_success:
+  - cd ..
+  - conda build ./recipe --old-build-string

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - ctest
 after_success:
   - cd ..
-  - conda build ./recipe
+  - conda build ./recipe --old-build-string
 after_script:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
-  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms --token=-
+  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms --old-build-string --token=-

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,6 @@ script:
 after_success:
   - cd ..
   - conda build ./recipe --old-build-string
-deploy:
+after_script:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
   - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - TRAVIS_PYTHON_VERSION="3.6"
     - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
+    - secure: "cyDcju3Edgnq0GXf5VLXPCaWYpOm/vbk01lhIpVEWun28opqrSdQ4qwyVUXgKtc4nh4bTvPqMaDEmvGFBoyAHFH/FQcETIwNMJOmRSXGSeIyZ/NPXDZVJUyeAt0Edj9WMUxvnNmGSDhpVrxWvL672O3STxSGXiLrp/qucIp9tmBAb6fT1DAggZEjDe6CZQ8t9OLalNYoGQ8YfC6KFccj9DYaB5JFPEpaWo/9F1xZuUf0JWs4fJbyHsrj8gs7oJQjNR0gKyh4+2JkE2JoVGIoPDU/1ISkrFSrnwppwE9CPfxD+2974n9iRzfYZLi9h6pvzDt27Cw0pziXG4ZP5+5Y7wgz31SAPUu6YkfmF5GVKFiaev0SLR6PXJQjAYa39k5eKAX8ENzIEF2ruE2Iqv2EPhJJyXtCnYcJicSL1Iq/69uCy9nAFxn4SlSbPYrg8lPTXhS/7rOzfqEwWapYxvklEqgbiK9MC30H5ejNgvUPlKya52iyYTm5H7ie97CIiF5Z5hZNcRd9K7RyHlLOehRf6yxt1jWt0k8HvC36ZDu1Po2OaMabMcI1t11y9w119ImzY9b6XfjWwDW1Ix0fcK3zfFFvLM7ennRf8hYtBuKIHcmX4a/ZK7q4rwWlxEgsbzElEOHO6aN/3lIE5qHclyE+bXLxJkbu7gAfcYYgZ16UQ2E="
 sudo: false
 before_install:
   - |
@@ -41,3 +42,6 @@ script:
 after_success:
   - cd ..
   - conda build ./recipe --old-build-string
+deploy:
+  - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
+  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ os:
   - linux
   - osx
 env:
-  global:
+  matrix:
+    - TRAVIS_PYTHON_VERSION="2.7"
     - TRAVIS_PYTHON_VERSION="3.6"
+    - TRAVIS_PYTHON_VERSION="3.7"
+  global:
     - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
     - secure: "cyDcju3Edgnq0GXf5VLXPCaWYpOm/vbk01lhIpVEWun28opqrSdQ4qwyVUXgKtc4nh4bTvPqMaDEmvGFBoyAHFH/FQcETIwNMJOmRSXGSeIyZ/NPXDZVJUyeAt0Edj9WMUxvnNmGSDhpVrxWvL672O3STxSGXiLrp/qucIp9tmBAb6fT1DAggZEjDe6CZQ8t9OLalNYoGQ8YfC6KFccj9DYaB5JFPEpaWo/9F1xZuUf0JWs4fJbyHsrj8gs7oJQjNR0gKyh4+2JkE2JoVGIoPDU/1ISkrFSrnwppwE9CPfxD+2974n9iRzfYZLi9h6pvzDt27Cw0pziXG4ZP5+5Y7wgz31SAPUu6YkfmF5GVKFiaev0SLR6PXJQjAYa39k5eKAX8ENzIEF2ruE2Iqv2EPhJJyXtCnYcJicSL1Iq/69uCy9nAFxn4SlSbPYrg8lPTXhS/7rOzfqEwWapYxvklEqgbiK9MC30H5ejNgvUPlKya52iyYTm5H7ie97CIiF5Z5hZNcRd9K7RyHlLOehRf6yxt1jWt0k8HvC36ZDu1Po2OaMabMcI1t11y9w119ImzY9b6XfjWwDW1Ix0fcK3zfFFvLM7ennRf8hYtBuKIHcmX4a/ZK7q4rwWlxEgsbzElEOHO6aN/3lIE5qHclyE+bXLxJkbu7gAfcYYgZ16UQ2E="

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ after_success:
   - conda build ./recipe --old-build-string
 after_script:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
-  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-
+  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms --old-build-string --token=-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,9 @@ package:
 
 source:
   git_url: https://github.com/csdms/{{ name }}
-  git_rev: v{{ version }}-beta
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:
@@ -26,6 +25,7 @@ requirements:
 test:
   commands:
     - run_heatf
+    - run_bmiheatf
 
 about:
   home: https://csdms.colorado.edu/wiki/BMI_Description

--- a/scripts/update_rpaths.sh
+++ b/scripts/update_rpaths.sh
@@ -29,3 +29,8 @@ tests=`ls -1 ./heat/tests/ | egrep "test_"`
 for exe in $tests; do
     run_install_name_tool $exe tests
 done
+
+mains="run_heatf run_bmiheatf"
+for exe in $mains; do
+    run_install_name_tool $exe $pwd
+done


### PR DESCRIPTION
This PR updates the Travis CI script to build the conda recipe and upload it to the Anaconda Cloud `csdms` channel after building, installing, and testing the bmi-fortran package.