### PR TITLE
Install module files to include directory

### DIFF
--- a/bmi/CMakeLists.txt
+++ b/bmi/CMakeLists.txt
@@ -17,4 +17,4 @@ install(
   DESTINATION lib/pkgconfig)
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
-  DESTINATION lib)
+  DESTINATION include)

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -33,4 +33,4 @@ install(
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
         ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmiheat_lib}.mod
-  DESTINATION lib)
+  DESTINATION include)


### PR DESCRIPTION
Fortran **.mod** files should be installed in the **include** directory, not the **lib** directory. This PR makes this change. The resulting install now looks like:

```
_install/
|-- bin
|   |-- run_bmiheatf
|   `-- run_heatf
|-- include
|   |-- bmif.mod
|   |-- bmiheatf.mod
|   `-- heatf.mod
`-- lib
    |-- libbmif.so
    |-- libbmiheatf.so
    `-- pkgconfig
        |-- bmif.pc
        `-- heatf.pc
```

Note that this may break my Fortran interoperability code in https://github.com/csdms/cookiecutter-bmi-wrap.

This fixes #32.