### PR TITLE
Use BMI version in module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 env:
   matrix:
-    - TRAVIS_PYTHON_VERSION="3.7"
+    - TRAVIS_PYTHON_VERSION="3.*"
   global:
     - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,18 @@ project(bmif Fortran)
 set(bmi_major_version 1)
 set(bmi_minor_version 2)
 
+# Match the module name set in "bmi.f90".
+set(mod_name ${CMAKE_PROJECT_NAME}_${bmi_major_version}_${bmi_minor_version})
+
 add_library(${CMAKE_PROJECT_NAME} SHARED bmi.f90)
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
   VERSION ${bmi_major_version}.${bmi_minor_version}
+  PUBLIC_HEADER ${CMAKE_BINARY_DIR}/${mod_name}.mod
 )
 
 install(
   TARGETS ${CMAKE_PROJECT_NAME}
-  DESTINATION lib)
-install(
-  FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${bmi_major_version}_${bmi_minor_version}.mod
-  DESTINATION include)
+  DESTINATION lib
+  PUBLIC_HEADER
+    DESTINATION include
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 3.0)
 
 project(bmif Fortran)
+set(bmi_major_version 1)
+set(bmi_minor_version 2)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED bmi.f90)
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+  VERSION ${bmi_major_version}.${bmi_minor_version}
+)
 
 install(
   TARGETS ${CMAKE_PROJECT_NAME}
   DESTINATION lib)
 install(
-  FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.mod
+  FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}_${bmi_major_version}_${bmi_minor_version}.mod
   DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(bmif Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 add_library(${CMAKE_PROJECT_NAME} SHARED bmi.f90)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,11 @@ cmake_minimum_required(VERSION 3.0)
 
 project(bmif Fortran)
 
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-
 add_library(${CMAKE_PROJECT_NAME} SHARED bmi.f90)
 
 install(
   TARGETS ${CMAKE_PROJECT_NAME}
   DESTINATION lib)
 install(
-  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_PROJECT_NAME}.mod
+  FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.mod
   DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ The installation will look (on Linux) like:
 ```bash
 .
 |-- include
-|   `-- bmif.mod
+|   `-- bmif_1_2.mod
 `-- lib
-    `-- libbmif.so
+    |-- libbmif.so -> libbmif.so.1.2
+	    `-- libbmif.so.1.2
 ```
 
 Alternately,
@@ -47,8 +48,8 @@ into an Anaconda distribution with
 ## Use
 
 To write a BMI for a model,
-`use` the `bmif` module and implement all the BMI procedures
-included in the interface defined in `bmif`.
+`use` the `bmif_1_2` module and implement all the BMI procedures
+included in the interface defined therein.
 A sample implementation is given in the
 https://github.com/csdms/bmi-example-fortran
 repository.

--- a/bmi.f90
+++ b/bmi.f90
@@ -1,4 +1,4 @@
-module bmif
+module bmif_1_2
 
   implicit none
 
@@ -466,4 +466,4 @@ module bmif
 
   end interface
 
-end module bmif
+end module bmif_1_2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,9 @@ requirements:
     - {{ compiler('fortran') }}
 
 about:
-  home: https://bmi-spec.readthedocs.io
+  home: https://bmi.readthedocs.io
   license: MIT
+  license_file: LICENSE
   summary:
     Fortran bindings, created with Fortran 2003, for the Basic Model Interface.
   dev_url: https://github.com/csdms/bmi-fortran


### PR DESCRIPTION
This PR introduces an interesting change to the Fortran BMI specification. To prevent collisions between BMI versions, I've appended the Fortran BMI version to the name of the module. So, what was

    module bmif

is now

    module bmif_1_2

where 1.2 is the BMI version. When compiled, this will produce the module file `bmif_1_2.mod`. Here's the updated tree of the install:
```
./
├── include
│   └── bmif_1_2.mod
└── lib
    ├── libbmif.so -> libbmif.so.1.2
    └── libbmif.so.1.2
```

Advantages of this approach:
* It doesn't use an unorthodox install path.
* It will be easy to see which version of the BMI is used.
* It shouldn't matter if the module file gets clobbered by another model's install
* Multiple BMI versions can exist
* It will work with either the user copying the BMI spec file to their build or the user installing the `bmi-fortran` package through conda

Disadvantages of this approach:
* It's awkward-looking.
* The user needs to import `bmif_1_2` instead of `bmif`.

Note that I also revised the cmake build process, since I keep learning more about cmake.

cc @wk1984 & @rmcd-mscb for opinions.
h/t @mgalloy for this idea.