### PR TITLE
Update build and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,23 @@ jobs:
         build-type: [Release]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          micromamba-version: latest
+          environment-name: testing
+          create-args: >-
+            make
+            cmake
+            fortran-compiler
+            c-compiler
+            cxx-compiler
+            mamba
 
       - name: Show conda installation info
-        run: conda info
-
-      - name: Install build tools and dependencies into env
         run: |
-          mamba install make cmake fortran-compiler
+          mamba info
           mamba list
 
       - name: Make cmake build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 project(bmif
   VERSION 2.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.0)
 
-# Use system-specific install directories
-include(GNUInstallDirs)
-
 project(bmif
   VERSION 2.0
   LANGUAGES Fortran
 )
+
+# Use system-specific install directories
+include(GNUInstallDirs)
 
 # Match the module name set in "bmi.f90".
 set(mod_name "${CMAKE_PROJECT_NAME}_\


### PR DESCRIPTION
This PR updates the CI to use micromamba instead of miniconda. It also makes two adjustments to the CMake build system: first, trivially moving the location of a statement to avert a warning message; second, updating the minimum required CMake version to avert this warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
``` 
I chose to update the minimum version to v3.12: it was released about 5 years before today, and it's >v3.5.