### PR TITLE
Disable conda compiler for CI on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,14 +82,11 @@ jobs:
       - name: Make cmake build directory
         run: cmake -E make_directory build
 
-      - name: Configure cmake
+      - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        working-directory: ${{ github.workspace }}/build
-        run: cmake --build . --target install --config Release
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --target install --config Release
 
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,9 @@ jobs:
           environment-name: testing
           create-args: >-
             cmake
-            fortran-compiler
             cxx-compiler
-            vs2019_win-64
+          init-shell: >-
+            powershell
 
       - name: Make cmake build directory
         run: cmake -E make_directory build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,21 +88,21 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:LIBRARY_PREFIX" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif.a
-          Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif_win.dll.a
-          Test-Path -Path $env:LIBRARY_PREFIX\bin\libbmif_win.dll
-          Test-Path -Path $env:LIBRARY_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\bin\libbmif_win.dll ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX\Library" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,9 @@ jobs:
 
     runs-on: windows-latest
 
+    env:
+      LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
+
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -85,21 +88,21 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX\Library" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="$env:LIBRARY_PREFIX" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path $env:CONDA_PREFIX\lib\libbmif.a
-          Test-Path -Path $env:CONDA_PREFIX\lib\libbmif_win.dll.a
-          Test-Path -Path $env:CONDA_PREFIX\bin\libbmif_win.dll
-          Test-Path -Path $env:CONDA_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif.a
+          Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif_win.dll.a
+          Test-Path -Path $env:LIBRARY_PREFIX\bin\libbmif_win.dll
+          Test-Path -Path $env:LIBRARY_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\bin\libbmif_win.dll ) ){ exit 1 }
-          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\lib\libbmif_win.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:LIBRARY_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - uses: ilammy/msvc-dev-cmd@v1
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: latest
@@ -78,8 +78,6 @@ jobs:
             fortran-compiler
             cxx-compiler
             vs2019_win-64
-
-      - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Make cmake build directory
         run: cmake -E make_directory build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,15 +91,15 @@ jobs:
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path %CONDA_PREFIX%\lib\libbmif.a
-          Test-Path -Path %CONDA_PREFIX%\lib\libbmif_win.dll.a
-          Test-Path -Path %CONDA_PREFIX%\bin\libbmif_win.dll
-          Test-Path -Path %CONDA_PREFIX%\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path $env:CONDA_PREFIX\lib\libbmif.a
+          Test-Path -Path $env:CONDA_PREFIX\lib\libbmif_win.dll.a
+          Test-Path -Path $env:CONDA_PREFIX\bin\libbmif_win.dll
+          Test-Path -Path $env:CONDA_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path %CONDA_PREFIX%\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path %CONDA_PREFIX%\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path %CONDA_PREFIX%\bin\libbmif_win.dll ) ){ exit 1 }
-          if ( -not ( Test-Path -Path %CONDA_PREFIX%\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libbmif.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\lib\libbmif_win.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To build the Fortran BMI bindings from source with cmake, run
     cmake .. -DCMAKE_INSTALL_PREFIX=<path-to-installation>
     make
 
-where `<path-to-installation>` is the base directory
-in which to install the bindings (`/usr/local` is the default).
+where `<path-to-installation>` is the base directory in which to install the bindings.
+The default is`/usr/local`.
+When using a conda environment,
+use the `$CONDA_PREFIX` environment variable.
 
 Then, to install:
 
@@ -68,9 +70,10 @@ run the following in a [Developer Command Prompt](https://docs.microsoft.com/en-
 	  -DCMAKE_INSTALL_PREFIX=<path-to-installation> ^
 	  -DCMAKE_BUILD_TYPE=Release
 
-where `<path-to-installation>` is the base directory
-in which to install the bindings (`"C:\Program Files (x86)"` is the default;
-note that quotes and an absolute path are needed).
+where `<path-to-installation>` is the base directory in which to install the bindings.
+The default is `"C:\Program Files (x86)"`.
+Note that quotes and an absolute path are needed.
+When using a conda environment, use `"%CONDA_PREFIX%\Library"`.
 
 Then, to build and install:
 


### PR DESCRIPTION
The Fortran conda compiler doesn't appear to be working on Windows when running CI on GitHub Actions (see #51). In this PR, I've removed it in favor of a gfortran install provided on the Windows platform used by Actions. I also noted the install location on Windows includes a `Library` prefix to the standard GNU install directories.