### PR TITLE
Improve build and test processes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=$env:FC -DCMAKE_INSTALL_PREFIX=$env:LIBRARY_PREFIX -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER="${{ env.FC }}" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
             cmake
             pkg-config
             cxx-compiler
+            fortran-compiler
           init-shell: >-
             powershell
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,8 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: |
           cmake .. -G Ninja ^
-            -DCMAKE_Fortran_COMPILER="${{ env.FC }}" ^
-            -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" ^
+            -DCMAKE_Fortran_COMPILER=$env.FC ^
+            -DCMAKE_INSTALL_PREFIX=$env.LIBRARY_PREFIX ^
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,17 +95,17 @@ jobs:
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmif.pc ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja ^
-            -DCMAKE_Fortran_COMPILER=$env.FC ^
-            -DCMAKE_INSTALL_PREFIX=$env.LIBRARY_PREFIX ^
-            -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=$env.FC -DCMAKE_INSTALL_PREFIX=$env.LIBRARY_PREFIX -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_Fortran_COMPILER="${{ env.LIBRARY_PREFIX }}\bin\flang-new.exe" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
 
     env:
       LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
+      FC: $env:LIBRARY_PREFIX\bin\flang-new.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +91,10 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_Fortran_COMPILER="${{ env.LIBRARY_PREFIX }}\bin\flang-new.exe" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja ^
+            -DCMAKE_Fortran_COMPILER="${{ env.FC }}" ^
+            -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" ^
+            -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
     env:
       LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
-      FC: ${env:LIBRARY_PREFIX}\bin\flang-new.exe
+      FC: $env:CONDA_PREFIX\Library\bin\flang-new.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=${env:FC} -DCMAKE_INSTALL_PREFIX=${env:LIBRARY_PREFIX} -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER="${{ env.FC }}" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,17 +100,17 @@ jobs:
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.dll.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_static.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_static.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmif.pc ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
     env:
       LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
-      FC: $env:LIBRARY_PREFIX\bin\flang-new.exe
+      FC: $env:CONDA_PREFIX\Library\bin\flang-new.exe
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=$env.FC -DCMAKE_INSTALL_PREFIX=$env.LIBRARY_PREFIX -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=$env:FC -DCMAKE_INSTALL_PREFIX=$env:LIBRARY_PREFIX -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ jobs:
   build-test-unix:
 
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 
@@ -63,8 +62,7 @@ jobs:
 
   build-test-windows:
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: windows-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
     env:
       LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
-      FC: $env:CONDA_PREFIX\Library\bin\flang-new.exe
+      FC: ${env:LIBRARY_PREFIX}\bin\flang-new.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Configure, build, and install
         working-directory: ${{ github.workspace }}/build
         run: |
-          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER="${{ env.FC }}" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_Fortran_COMPILER=${env:FC} -DCMAKE_INSTALL_PREFIX=${env:LIBRARY_PREFIX} -DCMAKE_BUILD_TYPE=Release
           cmake --build . --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,17 +95,17 @@ jobs:
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmif.pc ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,17 +95,17 @@ jobs:
       - name: Check (for humans)
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.dll.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif.dll
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_static.a
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif.dll ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_static.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmif.pc ) ){ exit 1 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,42 +18,42 @@ configure_file(
   @ONLY
 )
 
-# Create static and shared libraries.
-set(static_lib ${CMAKE_PROJECT_NAME}_static)
+# Create shared and static libraries through an object library.
 set(shared_lib ${CMAKE_PROJECT_NAME}_shared)
-add_library(${static_lib} bmi.f90)
-add_library(${shared_lib} SHARED bmi.f90)
+set(static_lib ${CMAKE_PROJECT_NAME}_static)
+add_library(obj_lib OBJECT bmi.f90)
+add_library(${shared_lib} SHARED $<TARGET_OBJECTS:obj_lib>)
+add_library(${static_lib} STATIC $<TARGET_OBJECTS:obj_lib>)
 
-# Change the output names of the libraries. On Windows, they can't
-# have the same name, so change the shared library name.
-set_target_properties(${static_lib} PROPERTIES
-  OUTPUT_NAME ${CMAKE_PROJECT_NAME})
-if(WIN32)
-  set_target_properties(${shared_lib} PROPERTIES
-    OUTPUT_NAME ${CMAKE_PROJECT_NAME}_win)
-else()
-  set_target_properties(${shared_lib} PROPERTIES
-    OUTPUT_NAME ${CMAKE_PROJECT_NAME})
-endif()
-
-set_target_properties(${static_lib} PROPERTIES
-  VERSION ${CMAKE_PROJECT_VERSION}
-)
-set_target_properties(${shared_lib} PROPERTIES
+set_target_properties(${shared_lib}
+  PROPERTIES
+  OUTPUT_NAME ${CMAKE_PROJECT_NAME}
   VERSION ${CMAKE_PROJECT_VERSION}
   PUBLIC_HEADER ${CMAKE_BINARY_DIR}/${mod_name}.mod
 )
 
-install(
-  TARGETS ${static_lib}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+set_target_properties(${static_lib}
+  PROPERTIES
+  OUTPUT_NAME ${CMAKE_PROJECT_NAME}
+  VERSION ${CMAKE_PROJECT_VERSION}
 )
+if(WIN32)
+  set_target_properties(${static_lib}
+    PROPERTIES
+    OUTPUT_NAME ${CMAKE_PROJECT_NAME}_static
+  )
+endif()
+
 install(
   TARGETS ${shared_lib}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  TARGETS ${static_lib}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 install(
   FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc

--- a/bmif.pc.cmake
+++ b/bmif.pc.cmake
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: bmi-fortran
 Description: The Basic Model Interface for Fortran
-URL: https://bmi.readthedocs.io
+URL: https://bmi.csdms.io
 Version: @CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@
 Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
This PR fixes a build error with *flang* 19.0.* on Windows (I was creating `bmif_2_0.med` twice, once each with the shared and the static library). I solved this using a CMake [object library](https://cmake.org/cmake/help/latest/command/add_library.html#object-libraries) as a base to build the shared and static libraries.

Another problem (that I've also seen elsewhere): the Windows platform used by Actions includes a *gcc* install with *gfortran*, and this *gfortran* is always found first in the path, before the *flang* installed in the `testing` conda environment. I solved this by setting the `CMAKE_Fortran_COMPILER` variable to the path to *flang-new.exe* in the conda environment.

Last, I switched build backends from NMake Makefiles to Ninja, which is what we use in our Meson-based projects. 