### PR TITLE
Fix CI and update build configuration on Windows 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
       run:
         shell: bash -l {0}
 
+    env:
+      SHLIB_EXT: ${{ matrix.os == 'ubuntu-latest' && '.so' || '.dylib' }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -45,15 +48,8 @@ jobs:
         run: |
           test -f $CONDA_PREFIX/include/bmif_$BMI_VERSION.mod
           test -s $CONDA_PREFIX/lib/libbmif.a
+          test -h $CONDA_PREFIX/lib/libbmif${{ env.SHLIB_EXT }}
           pkg-config --exists --print-errors bmif
-
-      - name: Test (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: test -h $CONDA_PREFIX/lib/libbmif.so
-
-      - name: Test (macOS)
-        if: matrix.os == 'macos-latest'
-        run: test -h $CONDA_PREFIX/lib/libbmif.dylib
 
   build-test-windows:
     if:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   BMI_VERSION: 2_0
+  BUILD_DIR: _build
 
 jobs:
   build-test-unix:
@@ -39,10 +40,10 @@ jobs:
 
       - name: Configure project
         run: |
-          cmake -B _build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
+          cmake -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
 
       - name: Build and install
-        run: cmake --build _build --target install --config Release
+        run: cmake --build ${{ env.BUILD_DIR }} --target install --config Release
 
       - name: Test
         run: |
@@ -81,8 +82,8 @@ jobs:
 
       - name: Configure, build, and install project
         run: |
-          cmake -B _build -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
-          cmake --build _build --target install --config Release
+          cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build ${{ env.BUILD_DIR }} --target install --config Release
 
       - name: Check (for humans)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Configure, build, and install project
         run: |
-          cmake -B _build -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake -B _build -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build _build --target install --config Release
 
       - name: Check (for humans)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,16 +86,16 @@ jobs:
 
       - name: Check (for humans)
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmif_win.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif.lib ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\bmif.dll ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmif_${{ env.BMI_VERSION }}.mod ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmif_static.lib ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\pkgconfig\bmif.pc ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,13 @@ jobs:
             cmake
             pkg-config
             cxx-compiler
+            fortran-compiler
           init-shell: >-
             powershell
+
+      - name: Set the FC environment variable to the Fortran conda compiler
+        run: |
+          echo "FC=$CONDA_PREFIX/Library/bin/flang-new.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Configure, build, and install project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ jobs:
   build-test-unix:
 
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 
@@ -63,8 +62,7 @@ jobs:
 
   build-test-windows:
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: windows-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,12 @@ jobs:
             pkg-config
             fortran-compiler
 
-      - name: Make cmake build directory
-        run: cmake -E make_directory build
-
-      - name: Configure cmake
-        working-directory: ${{ github.workspace }}/build
+      - name: Configure project
         run: |
-          cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
+          cmake -B _build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
 
       - name: Build and install
-        working-directory: ${{ github.workspace }}/build
-        run: cmake --build . --target install --config Release
+        run: cmake --build _build --target install --config Release
 
       - name: Test
         run: |
@@ -83,17 +78,12 @@ jobs:
           init-shell: >-
             powershell
 
-      - name: Make cmake build directory
-        run: cmake -E make_directory build
-
-      - name: Configure, build, and install
-        working-directory: ${{ github.workspace }}/build
+      - name: Configure, build, and install project
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
-          cmake --build . --target install --config Release
+          cmake -B _build -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build _build --target install --config Release
 
       - name: Check (for humans)
-        working-directory: ${{ github.workspace }}/build
         run: |
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a
           Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a
@@ -102,7 +92,6 @@ jobs:
           pkg-config --exists --print-errors bmif
 
       - name: Test (for machines)
-        working-directory: ${{ github.workspace }}/build
         run: |
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmif_win.dll.a ) ){ exit 1 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,25 +21,25 @@ configure_file(
 # Create static and shared libraries.
 set(static_lib ${CMAKE_PROJECT_NAME}_static)
 set(shared_lib ${CMAKE_PROJECT_NAME}_shared)
-add_library(${static_lib} bmi.f90)
-add_library(${shared_lib} SHARED bmi.f90)
+add_library(obj_lib OBJECT bmi.f90)
+add_library(${static_lib} STATIC $<TARGET_OBJECTS:obj_lib>)
+add_library(${shared_lib} SHARED $<TARGET_OBJECTS:obj_lib>)
 
-# Change the output names of the libraries. On Windows, they can't
-# have the same name, so change the shared library name.
-set_target_properties(${static_lib} PROPERTIES
-  OUTPUT_NAME ${CMAKE_PROJECT_NAME})
-if(WIN32)
-  set_target_properties(${shared_lib} PROPERTIES
-    OUTPUT_NAME ${CMAKE_PROJECT_NAME}_win)
-else()
-  set_target_properties(${shared_lib} PROPERTIES
-    OUTPUT_NAME ${CMAKE_PROJECT_NAME})
-endif()
-
-set_target_properties(${static_lib} PROPERTIES
+set_target_properties(${static_lib}
+  PROPERTIES
+  OUTPUT_NAME ${CMAKE_PROJECT_NAME}
   VERSION ${CMAKE_PROJECT_VERSION}
 )
-set_target_properties(${shared_lib} PROPERTIES
+if(WIN32)
+  set_target_properties(${static_lib}
+    PROPERTIES
+    OUTPUT_NAME ${CMAKE_PROJECT_NAME}_static
+  )
+endif()
+
+set_target_properties(${shared_lib}
+  PROPERTIES
+  OUTPUT_NAME ${CMAKE_PROJECT_NAME}
   VERSION ${CMAKE_PROJECT_VERSION}
   PUBLIC_HEADER ${CMAKE_BINARY_DIR}/${mod_name}.mod
 )

--- a/bmif.pc.cmake
+++ b/bmif.pc.cmake
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: bmi-fortran
 Description: The Basic Model Interface for Fortran
-URL: https://bmi.readthedocs.io
+URL: https://bmi.csdms.io
 Version: @CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@
 Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
This PR started as an attempt to force CMake to find the conda Fortran compiler, *flang-new*, on Windows instead of the *gfortran* that's packaged with the GitHub Actions runner. Setting the `FC` environment variable worked! But the NMake build backend failed. I changed the build backend to Ninja, which is used in Meson projects, but it also failed, although with a helpful message:

```pwsh
ninja: build stopped: multiple rules generate bmif_2_0.mod.
Error: Process completed with exit code 1.
```

The module file `bmif_2_0.mod` was being created twice, once when building the shared library and again when building the static library. This issue hadn't been raised by NMake. I modified the CMake build configuration to use a CMake [object library](https://cmake.org/cmake/help/latest/command/add_library.html#object-libraries) as a base to build the shared and static libraries. This made only one version of `bmif_2_0.mod`. I also matched other libraries (e.g., *bz2* and *bzip2*) in appending `_static` to the static library name.

Interestingly, *flang-new* creates different filenames than *gfortran*; e.g., `bmif.lib` instead of `libbmif.a`. I updated the tests to work for the filenames generated by *flang-new*.

This fixes #51.
